### PR TITLE
JDG-57-handle-barcode-errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Handled barcode128 generation errors to be able to pre compile without interrupting the process
 
 ## [2.0.2] - 2022-04-18
 ### Fixed

--- a/lib/controllers/pre-compile.js
+++ b/lib/controllers/pre-compile.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const logger = require('lllog')();
+
 // Format Code libs
 const QRCode = require('qrcode');
 const bwipjs = require('bwip-js');
@@ -125,21 +127,27 @@ module.exports = class HTMLPreCompileController {
 	/**
 	 * Generate BarCode128 Images
 	 * @param {string|number|boolean|object|Array} qrData Data to convert to BarCode128 Image
-	 * @returns {Promise<string>} BarCode128 Image in Buffer to add to <img /> Tag
+	 * @returns {string} BarCode128 Image in Buffer to add to <img /> Tag or undefined if failed to generate the barcode
 	 */
 	async generateBarcode128(barcode128Data) {
 
-		const barcodeBuffer = await bwipjs.toBuffer({
-			bcid: 'code128',
-			text: barcode128Data,
-			scale: 3,
-			height: 10,
-			includetext: true,
-			textxaling: 'center'
-		});
+		try {
 
-		const barcodeString64 = barcodeBuffer.toString('base64');
+			const barcodeBuffer = await bwipjs.toBuffer({
+				bcid: 'code128',
+				text: barcode128Data,
+				scale: 3,
+				height: 10,
+				includetext: true,
+				textxaling: 'center'
+			});
 
-		return `data:image/png;base64,${barcodeString64}`;
+			const barcodeString64 = barcodeBuffer.toString('base64');
+
+			return `data:image/png;base64,${barcodeString64}`;
+
+		} catch(err) {
+			logger.warn(`Unable to generate barcode: ${err.message}`);
+		}
 	}
 };

--- a/lib/controllers/pre-compile.js
+++ b/lib/controllers/pre-compile.js
@@ -26,7 +26,7 @@ module.exports = class HTMLPreCompileController {
 			throw new Error('Template Values must be an object');
 
 		if(!Object.keys(templateValues).length)
-			throw new Error('Template values must\n be empty object');
+			throw new Error('Template values can\'t be an empty object');
 
 		return this.format(templateValues);
 	}

--- a/package-lock.json
+++ b/package-lock.json
@@ -2049,6 +2049,11 @@
         "type-check": "~0.4.0"
       }
     },
+    "lllog": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/lllog/-/lllog-1.1.2.tgz",
+      "integrity": "sha512-NlDBErdptc08mgu1PeNFzlz+mNY2fIPMKTBujhPEHjmPkiW4J5iiRu8hh7VuRVtCeiZTNsmXRnE8wUFNdsov/w=="
+    },
     "load-json-file": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "date-fns": "^2.28.0",
     "date-fns-tz": "^1.3.3",
     "handlebars": "^4.7.7",
+    "lllog": "^1.1.2",
     "qrcode": "^1.4.4"
   }
 }

--- a/tests/handlebars-pre-compile-test.js
+++ b/tests/handlebars-pre-compile-test.js
@@ -1,7 +1,9 @@
 'use strict';
 
+require('lllog')('none');
+
 const assert = require('assert');
-const sandbox = require('sinon').createSandbox();
+const sinon = require('sinon');
 const QRCode = require('qrcode');
 const bwipjs = require('bwip-js');
 
@@ -32,9 +34,9 @@ describe('Handlebars PreCompile', () => {
 			}
 		];
 
-		sandbox.spy(QRCode, 'toDataURL');
+		sinon.spy(QRCode, 'toDataURL');
 
-		sandbox.spy(bwipjs, 'toBuffer');
+		sinon.spy(bwipjs, 'toBuffer');
 
 		templateValues.forEach(({ type, value }) => {
 
@@ -42,9 +44,9 @@ describe('Handlebars PreCompile', () => {
 
 				assert.throws(() => Handlebars.preCompile(value), { name: 'Error', message: 'Template Values must be an object' });
 
-				sandbox.assert.notCalled(QRCode.toDataURL);
+				sinon.assert.notCalled(QRCode.toDataURL);
 
-				sandbox.assert.notCalled(bwipjs.toBuffer);
+				sinon.assert.notCalled(bwipjs.toBuffer);
 			});
 		});
 
@@ -52,9 +54,9 @@ describe('Handlebars PreCompile', () => {
 
 			assert.throws(() => Handlebars.preCompile({}), { name: 'Error', message: 'Template values must\n be empty object' });
 
-			sandbox.assert.notCalled(QRCode.toDataURL);
+			sinon.assert.notCalled(QRCode.toDataURL);
 
-			sandbox.assert.notCalled(bwipjs.toBuffer);
+			sinon.assert.notCalled(bwipjs.toBuffer);
 		});
 	});
 
@@ -62,7 +64,7 @@ describe('Handlebars PreCompile', () => {
 	context('When the document must render QR Code', () => {
 
 		beforeEach(() => {
-			sandbox.restore();
+			sinon.restore();
 		});
 
 		const qr = 'https://www.google.com/';
@@ -88,7 +90,7 @@ describe('Handlebars PreCompile', () => {
 
 		it('Should return the qr replaced when it is an string', async () => {
 
-			sandbox.stub(QRCode, 'toDataURL').resolves(qrCode);
+			sinon.stub(QRCode, 'toDataURL').resolves(qrCode);
 
 			const preCompileResponse = await Handlebars.preCompile(data);
 
@@ -97,7 +99,7 @@ describe('Handlebars PreCompile', () => {
 
 		it('Should return the qr replaced when it is an object', async () => {
 
-			sandbox.stub(QRCode, 'toDataURL').resolves(qrCode);
+			sinon.stub(QRCode, 'toDataURL').resolves(qrCode);
 
 			const preCompileResponse = await Handlebars.preCompile({ ...data, qr_data: qrObject });
 
@@ -106,7 +108,7 @@ describe('Handlebars PreCompile', () => {
 
 		it('Should return the qr replaced when it is an array', async () => {
 
-			sandbox.stub(QRCode, 'toDataURL').resolves(qrCode);
+			sinon.stub(QRCode, 'toDataURL').resolves(qrCode);
 
 			const preCompileResponse = await Handlebars.preCompile({ ...data, qr_data: qrArray });
 
@@ -126,7 +128,7 @@ describe('Handlebars PreCompile', () => {
 				]
 			};
 
-			sandbox.stub(QRCode, 'toDataURL').resolves(qrCode);
+			sinon.stub(QRCode, 'toDataURL').resolves(qrCode);
 
 			const preCompileResponse = await Handlebars.preCompile(dataWithArray);
 
@@ -152,7 +154,7 @@ describe('Handlebars PreCompile', () => {
 				}
 			};
 
-			sandbox.stub(QRCode, 'toDataURL').resolves(qrCode);
+			sinon.stub(QRCode, 'toDataURL').resolves(qrCode);
 
 			const preCompileResponse = await Handlebars.preCompile(dataWithObject);
 
@@ -169,7 +171,7 @@ describe('Handlebars PreCompile', () => {
 	context('When the document must render Barcode128 Code', () => {
 
 		beforeEach(() => {
-			sandbox.restore();
+			sinon.restore();
 		});
 
 		const barCode128 = '123123';
@@ -193,7 +195,7 @@ describe('Handlebars PreCompile', () => {
 
 		it('Should return the barcode128 replaced when it is an string', async () => {
 
-			sandbox.stub(bwipjs, 'toBuffer').resolves(barcode128Code);
+			sinon.stub(bwipjs, 'toBuffer').resolves(barcode128Code);
 
 			const preCompileResponse = await Handlebars.preCompile(data);
 
@@ -216,7 +218,7 @@ describe('Handlebars PreCompile', () => {
 				]
 			};
 
-			sandbox.stub(bwipjs, 'toBuffer').resolves(barcode128Code);
+			sinon.stub(bwipjs, 'toBuffer').resolves(barcode128Code);
 
 			const preCompileResponse = await Handlebars.preCompile(dataWithArray);
 
@@ -233,6 +235,15 @@ describe('Handlebars PreCompile', () => {
 					}
 				]
 			});
+		});
+
+		it('Should return undefined when it fails to generate the barcode (not supported characters)', async () => {
+
+			sinon.spy(bwipjs, 'toBuffer');
+
+			const preCompileResponse = await Handlebars.preCompile({ ...data, barcode128_ean: 'elcaimán_09090' });
+
+			assert.deepStrictEqual(preCompileResponse, { ...response, barcode128_ean: undefined });
 		});
 	});
 });

--- a/tests/handlebars-pre-compile-test.js
+++ b/tests/handlebars-pre-compile-test.js
@@ -52,7 +52,7 @@ describe('Handlebars PreCompile', () => {
 
 		it('Should return an error when pass a empty object', () => {
 
-			assert.throws(() => Handlebars.preCompile({}), { name: 'Error', message: 'Template values must\n be empty object' });
+			assert.throws(() => Handlebars.preCompile({}), { name: 'Error', message: 'Template values can\'t be an empty object' });
 
 			sinon.assert.notCalled(QRCode.toDataURL);
 


### PR DESCRIPTION
**LINK AL TICKET**
https://fizzmod.atlassian.net/browse/JDG-57

**LINK A LA HISTORIA**
https://fizzmod.atlassian.net/browse/JDG-55

**DESCRIPCIÓN DEL REQUERIMIENTO**
- Agregar un try/catch en la generacion del barcode para evitar que rompa todo cuando se intenta generar un barcode con caracteres no soportados como letras con tilde y que pueda generar los demás datos.

**DESCRIPCIÓN DE LA SOLUCIÓN**
- Se realizaron los cambios solicitados

**COMO SE PUEDE PROBAR?**
Ya esta probado, pero si lo queres probar, podes hacerlo localmente, instalando el package y usar el método `preCompile` con un template que en su `barcode218_ean` tenga caracteres no soportados, en el resultado, `barcode128_ean` debería ser `undefined`