### PR TITLE
agregar-caso-test-para-sumArray-helper

### DIFF
--- a/docs/helpers.md
+++ b/docs/helpers.md
@@ -1351,36 +1351,73 @@ Something is true
 > Returns the sum of all the elements of an array
 
 **Parameters**
-* `array`:
-	* type: `array` - The array that contains the elements to sum
-* `key`:
-	* type: `array` - The property that contains the number to sum in case the array contains object. If not set, an array of number will be assumed.
+
+- `array`:
+  - type: `array` - The array that contains the elements to sum
+- `key`:
+  - type: `string` - The property that contains the number to sum in case the array contains object. It can passed as a property of the data or as string. If not set, an array of number will be assumed.
+
+**First case**
 
 **:computer: Template**
 
 ```handlebars
-<p>{{sumArray items price}}</p>
+<p>{{sumArray items key}}</p>
 ```
 
 **:inbox_tray: Values**
+
 ```js
 {
-	items: [
-		{
-			name: 'Carrot',
-			price: 10
-		},
-		{
-			name: 'Lettuce',
-			price: 15
-		}
-	]
+  items: [
+    {
+      name: 'Carrot',
+      price: 10,
+    },
+    {
+      name: 'Lettuce',
+      price: 15,
+    },
+  ],
+	key: 'price'
 }
 ```
 
 **:sparkles: Result**
+
 ```html
 <p>25</p>
+```
+
+**Second case**
+
+**:computer: Template**
+
+```handlebars
+<p>{{sumArray items 'price'}}</p>
+```
+
+**:inbox_tray: Values**
+
+```js
+{
+  items: [
+    {
+      name: 'Carrot',
+      price: 20,
+    },
+    {
+      name: 'Lettuce',
+      price: 30,
+    },
+  ];
+}
+```
+
+**:sparkles: Result**
+
+```html
+<p>50</p>
 ```
 
 </details>

--- a/tests/handlebars-helpers-test.js
+++ b/tests/handlebars-helpers-test.js
@@ -279,6 +279,22 @@ describe('Handlebars Helpers', () => {
 
 			assert.strictEqual(templateCompiled(value), '<html><body><h1>4</h1></body></html>');
 		});
+
+		const secondTemplate = '<html><body><h1>{{sumArray array "number"}}</h1></body></html>';
+		const secondTemplateCompiled = Handlebars.compile(secondTemplate, 'strict');
+
+		it('Should return the sum of all numbers in the array in html with the second parameter as a string', () => {
+
+			const value = {
+				array: [
+					{ number: 1 },
+					{ number: 2 },
+					{ number: 3 }
+				]
+			};
+
+			assert.strictEqual(secondTemplateCompiled(value), '<html><body><h1>6</h1></body></html>');
+		});
 	});
 
 	context('When must render using customFormatPrice helper', () => {


### PR DESCRIPTION
## Descripción

Para el helper `sumArray`, se encontró un caso donde se puede pasar el segundo parámetro como string cuando los elementos a iterar son objetos, ejemplo:

```javascript
const value = {
	array: [
		{ number: 1 },
		{ number: 2 },
		{ number: 3 }
	]
};

{{ sumArray array 'number' }}
``` 

Salida: **6**

## Solución

Se agregó un nuevo test en _tests/handlebars-helpers-test.js_ dentro del scope de este helper para contemplar este caso.