### PR TITLE
Jcn 465 manage short links

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -10,7 +10,8 @@ module.exports = {
 	},
 
 	parserOptions: {
-		sourceType: 'script'
+		sourceType: 'script',
+		ecmaVersion: 2020
 	},
 
 	rules: {

--- a/docs/helpers.md
+++ b/docs/helpers.md
@@ -1476,7 +1476,7 @@ Something is true
 <summary><b>Expression</b>: Formatted a link for a provided URL</summary>
 
 > Return the link with this format #SHORTLINK[link].
-> If the link is not a valid URL, return 'Invalid URL'
+> If the link is not a valid URL, return an empty string
 
 **Parameters**
 * `value`:
@@ -1509,7 +1509,7 @@ Something is true
 
 **:sparkles: Result**
 ```html
-<p>Invalid URL</p>
+<p></p>
 ```
 
 **:computer: Template**

--- a/docs/helpers.md
+++ b/docs/helpers.md
@@ -1470,6 +1470,63 @@ Something is true
 
 </details>
 
+### `shortLink`
+
+<details>
+<summary><b>Expression</b>: Formatted a link for a provided URL</summary>
+
+> Return the link with this format #SHORTLINK[link].
+> If the link is not a valid URL, return 'Invalid URL'
+
+**Parameters**
+* `value`:
+	* type: `string` - The URL to be used for creating the formatted link
+
+**:computer: Template**
+
+```handlebars
+<p>{{shortLink url}}</p>
+```
+
+**:inbox_tray: Values**
+```js
+{
+	url: 'https://janis.im'
+}
+```
+
+**:sparkles: Result**
+```html
+<p>#SHORTLINK[https://janis.im]</p>
+```
+
+**:inbox_tray: Values**
+```js
+{
+	url: 'janis.im'
+}
+```
+
+**:sparkles: Result**
+```html
+<p>Invalid URL</p>
+```
+
+**:computer: Template**
+
+```handlebars
+<p>{{shortLink "https://janis.im"}}</p>
+```
+
+**:sparkles: Result**
+```html
+<p>#SHORTLINK[https://janis.im]</p>
+```
+
+</details>
+
+
+
 ## :x: Deprecated helpers
 
 ### `concat`

--- a/lib/controllers/post-compile.js
+++ b/lib/controllers/post-compile.js
@@ -17,39 +17,30 @@ module.exports = class HTMLPostCompileController {
 		if(!coincidences)
 			return template;
 
-		const shortLinksByLink = await this.getShortlinks(coincidences);
+		const uniqueConcidences = new Set(coincidences);
 
-		return Object.entries(shortLinksByLink).reduce((result, [longLink, shortLink]) => {
-			const exp = new RegExp('#SHORTLINK\\[' + longLink + '\\]', 'g'); // Está sujeto solo al #SHORTLINK
+		this.shortLinksByLink = {};
+
+		await Promise.all(Array.from(uniqueConcidences).map(link => this.getShortlink(link)));
+
+		return Object.entries(this.shortLinksByLink).reduce((result, [longLink, shortLink]) => {
+			const exp = new RegExp('#SHORTLINK\\[' + longLink + '\\]', 'g');
 			return result.replace(exp, shortLink);
 		}, template);
 	}
 
-	async getShortlinks(links) {
+	async getShortlink(wrappedlink) {
 
-		const shortenedLinks = links.reduce(async (results, wrappedlink) => {
+		const originalLink = wrappedlink.slice(11, -1); // Extract link from '#SHORTLINK[link]'
 
-			const actualResults = await results;
+		if(!this.shortLink) {
 
-			const originalLink = wrappedlink.slice(11, -1); // Solo funciona con formato #SHORTLINK[link]
+			this.shortLinksByLink[originalLink] = originalLink;
+			return;
+		}
 
-			if(actualResults[originalLink])
-				return actualResults;
+		const { payload: { shortUrl } } = await Invoker.serviceSafeCall('link', 'CreateLink', { target: originalLink });
 
-
-			if(!this.shortLink) {
-				actualResults[originalLink] = originalLink;
-				return actualResults;
-			}
-
-			const { payload: { shortUrl } } = await Invoker.serviceSafeCall('link', 'CreateLink', { target: originalLink });
-
-			actualResults[originalLink] = shortUrl || originalLink;
-
-			return actualResults;
-
-		}, {});
-
-		return shortenedLinks;
+		this.shortLinksByLink[originalLink] = shortUrl || originalLink;
 	}
 };

--- a/lib/controllers/post-compile.js
+++ b/lib/controllers/post-compile.js
@@ -35,13 +35,7 @@ module.exports = class HTMLPostCompileController {
 
 		const originalLink = wrappedlink.slice(11, -1); // Extract link from '#SHORTLINK[link]'
 
-		if(!this.shortLink) {
-
-			this.shortLinksByLink[originalLink] = originalLink;
-			return;
-		}
-
-		const response = await Invoker.serviceSafeCall('link', 'CreateLink', { target: originalLink });
+		const response = this.shortLink && await Invoker.serviceSafeCall('link', 'CreateLink', { target: originalLink });
 
 		this.shortLinksByLink[originalLink] = response?.payload?.shortUrl || originalLink;
 	}

--- a/lib/controllers/post-compile.js
+++ b/lib/controllers/post-compile.js
@@ -9,7 +9,7 @@ const pattern = /#SHORTLINK\[[^\]]+\]/g;
 module.exports = class HTMLPostCompileController {
 
 	constructor(settings = {}) {
-		this.shortLink = settings.hasOwnProperty('shortLink') ? settings.shortLink : true;
+		this.shortLink = settings?.shortLink ?? true;
 	}
 
 	async process(template) {
@@ -26,7 +26,7 @@ module.exports = class HTMLPostCompileController {
 		await Promise.all(Array.from(uniqueConcidences).map(link => this.getShortlink(link)));
 
 		return Object.entries(this.shortLinksByLink).reduce((result, [longLink, shortLink]) => {
-			const exp = new RegExp('#SHORTLINK\\[' + escapeRegExp(longLink) + '\\]', 'g');
+			const exp = new RegExp(`#SHORTLINK\\[${escapeRegExp(longLink)}\\]`, 'g');
 			return result.replace(exp, shortLink);
 		}, template);
 	}
@@ -41,8 +41,8 @@ module.exports = class HTMLPostCompileController {
 			return;
 		}
 
-		const { payload: { shortUrl } } = await Invoker.serviceSafeCall('link', 'CreateLink', { target: originalLink });
+		const response = await Invoker.serviceSafeCall('link', 'CreateLink', { target: originalLink });
 
-		this.shortLinksByLink[originalLink] = shortUrl || originalLink;
+		this.shortLinksByLink[originalLink] = response?.payload?.shortUrl || originalLink;
 	}
 };

--- a/lib/controllers/post-compile.js
+++ b/lib/controllers/post-compile.js
@@ -1,0 +1,55 @@
+'use strict';
+
+const { Invoker } = require('@janiscommerce/lambda');
+
+const pattern = /#SHORTLINK\[[^\]]+\]/g; // Guardar el patrón segín el tipo de wrapper
+
+module.exports = class HTMLPostCompileController {
+
+	constructor(settings = {}) {
+		this.shortLink = settings.hasOwnProperty('shortLink') ? settings.shortLink : true;
+	}
+
+	async process(template) {
+
+		const coincidences = template.match(pattern);
+
+		if(!coincidences)
+			return template;
+
+		const shortLinksByLink = await this.getShortlinks(coincidences);
+
+		return Object.entries(shortLinksByLink).reduce((result, [longLink, shortLink]) => {
+			const exp = new RegExp('#SHORTLINK\\[' + longLink + '\\]', 'g'); // Está sujeto solo al #SHORTLINK
+			return result.replace(exp, shortLink);
+		}, template);
+	}
+
+	async getShortlinks(links) {
+
+		const shortenedLinks = links.reduce(async (results, wrappedlink) => {
+
+			const actualResults = await results;
+
+			const originalLink = wrappedlink.slice(11, -1); // Solo funciona con formato #SHORTLINK[link]
+
+			if(actualResults[originalLink])
+				return actualResults;
+
+
+			if(!this.shortLink) {
+				actualResults[originalLink] = originalLink;
+				return actualResults;
+			}
+
+			const { payload: { shortUrl } } = await Invoker.serviceSafeCall('link', 'CreateLink', { target: originalLink });
+
+			actualResults[originalLink] = shortUrl || originalLink;
+
+			return actualResults;
+
+		}, {});
+
+		return shortenedLinks;
+	}
+};

--- a/lib/controllers/post-compile.js
+++ b/lib/controllers/post-compile.js
@@ -2,7 +2,9 @@
 
 const { Invoker } = require('@janiscommerce/lambda');
 
-const pattern = /#SHORTLINK\[[^\]]+\]/g; // Guardar el patrón segín el tipo de wrapper
+const { escapeRegExp } = require('../utils');
+
+const pattern = /#SHORTLINK\[[^\]]+\]/g;
 
 module.exports = class HTMLPostCompileController {
 
@@ -24,7 +26,7 @@ module.exports = class HTMLPostCompileController {
 		await Promise.all(Array.from(uniqueConcidences).map(link => this.getShortlink(link)));
 
 		return Object.entries(this.shortLinksByLink).reduce((result, [longLink, shortLink]) => {
-			const exp = new RegExp('#SHORTLINK\\[' + longLink + '\\]', 'g');
+			const exp = new RegExp('#SHORTLINK\\[' + escapeRegExp(longLink) + '\\]', 'g');
 			return result.replace(exp, shortLink);
 		}, template);
 	}

--- a/lib/handlebars.js
+++ b/lib/handlebars.js
@@ -52,7 +52,7 @@ const {
 	formatWeight,
 	base1Index,
 	formatDate,
-	shortlink
+	shortLink
 } = require('./helpers');
 
 Handlebars.registerHelper('concat', concat);
@@ -147,7 +147,7 @@ Handlebars.registerHelper('base1Index', base1Index);
 
 Handlebars.registerHelper('formatDate', formatDate);
 
-Handlebars.registerHelper('shortLink', shortlink);
+Handlebars.registerHelper('shortLink', shortLink);
 
 Handlebars.preCompile = templateValues => {
 

--- a/lib/handlebars.js
+++ b/lib/handlebars.js
@@ -3,6 +3,7 @@
 const Handlebars = require('handlebars');
 
 const HTMLPreCompileController = require('./controllers/pre-compile');
+const HTMLPostCompileController = require('./controllers/post-compile');
 
 const {
 	concat,
@@ -153,6 +154,13 @@ Handlebars.preCompile = templateValues => {
 	const preCompileController = new HTMLPreCompileController();
 
 	return preCompileController.process(templateValues);
+};
+
+Handlebars.postCompile = (template, settings) => {
+
+	const preCompileController = new HTMLPostCompileController(settings);
+
+	return preCompileController.process(template);
 };
 
 module.exports = Handlebars;

--- a/lib/handlebars.js
+++ b/lib/handlebars.js
@@ -50,7 +50,8 @@ const {
 	formatNumber,
 	formatWeight,
 	base1Index,
-	formatDate
+	formatDate,
+	shortlink
 } = require('./helpers');
 
 Handlebars.registerHelper('concat', concat);
@@ -144,6 +145,8 @@ Handlebars.registerHelper('isNegative', isNegative);
 Handlebars.registerHelper('base1Index', base1Index);
 
 Handlebars.registerHelper('formatDate', formatDate);
+
+Handlebars.registerHelper('shortLink', shortlink);
 
 Handlebars.preCompile = templateValues => {
 

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -2,6 +2,7 @@
 
 const Handlebars = require('handlebars');
 const util = require('util');
+const { URL } = require('url');
 const zones = require('date-fns/locale');
 const { format: fnsFormat, utcToZonedTime } = require('date-fns-tz');
 const Decimal = require('decimal.js').default;
@@ -269,7 +270,7 @@ module.exports.regexReplace = (text, search, flags, replace) => {
  * @example {{stripHost url}} => /search
  * @deprecated
  */
-module.exports.stripHost = URL => URL.toString().replace(/https?:\/\/.*?\//i, '/');
+module.exports.stripHost = url => url.toString().replace(/https?:\/\/.*?\//i, '/');
 
 /**
  * Camelize a string
@@ -725,4 +726,22 @@ module.exports.formatDate = (date, format, ...restOfParams) => {
 	} catch(e) {
 		return e.message;
 	}
+};
+
+/**
+ * Creates a formatted link for a provided URL.
+ *
+ * @param {string} value - The URL to be used for creating the formatted link.
+ * @returns {string} - If the URL is valid, returns a formatted link.
+ *                    If the URL is invalid, returns 'Invalid URL'.
+ */
+module.exports.shortlink = value => {
+
+	try {
+		new URL(value);
+		return `#SHORTLINK[${value}]`;
+	} catch(error) {
+		return 'Invalid URL';
+	}
+
 };

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -733,17 +733,9 @@ module.exports.formatDate = (date, format, ...restOfParams) => {
  *
  * @param {string} value - The URL to be used for creating the formatted link.
  * @returns {string} - A formatted link if the URL is valid, otherwise an empty string.
- * @example
- *
- * const invalidURL = 'not_a_valid_url';
- *
- * console.log(shortlink('https://example.com'));
- * // Output: '#SHORTLINK[https://example.com]'
- *
- * console.log(shortlink('not_a_valid_url'));
- * // Output: ''
+ * @example {{shortlink url}} ==> "#SHORTLINK[https://example.com]"
  */
-module.exports.shortlink = value => {
+module.exports.shortLink = value => {
 
 	try {
 		new URL(value);

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -732,8 +732,16 @@ module.exports.formatDate = (date, format, ...restOfParams) => {
  * Creates a formatted link for a provided URL.
  *
  * @param {string} value - The URL to be used for creating the formatted link.
- * @returns {string} - If the URL is valid, returns a formatted link.
- *                    If the URL is invalid, returns 'Invalid URL'.
+ * @returns {string} - A formatted link if the URL is valid, otherwise an empty string.
+ * @example
+ *
+ * const invalidURL = 'not_a_valid_url';
+ *
+ * console.log(shortlink('https://example.com'));
+ * // Output: '#SHORTLINK[https://example.com]'
+ *
+ * console.log(shortlink('not_a_valid_url'));
+ * // Output: ''
  */
 module.exports.shortlink = value => {
 
@@ -741,7 +749,7 @@ module.exports.shortlink = value => {
 		new URL(value);
 		return `#SHORTLINK[${value}]`;
 	} catch(error) {
-		return 'Invalid URL';
+		return '';
 	}
 
 };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -32,3 +32,5 @@ module.exports.parseDecimal = (number, decimal, length) => {
 
 	return newNumber.replace('.', (decimal || ','));
 };
+
+module.exports.escapeRegExp = text => text.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,905 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@aws-crypto/crc32": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-3.0.0.tgz",
+      "integrity": "sha512-IzSgsrxUcsrejQbPVilIKy16kAT52EwB6zSaI+M3xxIhKh5+aldEyvI+z6erM7TCLB2BJsFrtHjp6/4/sr+3dA==",
+      "requires": {
+        "@aws-crypto/util": "^3.0.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-crypto/crc32c": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32c/-/crc32c-3.0.0.tgz",
+      "integrity": "sha512-ENNPPManmnVJ4BTXlOjAgD7URidbAznURqD0KvfREyc4o20DPYdEldU1f5cQ7Jbj0CJJSPaMIk/9ZshdB3210w==",
+      "requires": {
+        "@aws-crypto/util": "^3.0.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-crypto/ie11-detection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-3.0.0.tgz",
+      "integrity": "sha512-341lBBkiY1DfDNKai/wXM3aujNBkXR7tq1URPQDL9wi3AUbI80NR74uF1TXHMm7po1AcnFk8iu2S2IeU/+/A+Q==",
+      "requires": {
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-crypto/sha1-browser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha1-browser/-/sha1-browser-3.0.0.tgz",
+      "integrity": "sha512-NJth5c997GLHs6nOYTzFKTbYdMNA6/1XlKVgnZoaZcQ7z7UJlOgj2JdbHE8tiYLS3fzXNCguct77SPGat2raSw==",
+      "requires": {
+        "@aws-crypto/ie11-detection": "^3.0.0",
+        "@aws-crypto/supports-web-crypto": "^3.0.0",
+        "@aws-crypto/util": "^3.0.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-crypto/sha256-browser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-3.0.0.tgz",
+      "integrity": "sha512-8VLmW2B+gjFbU5uMeqtQM6Nj0/F1bro80xQXCW6CQBWgosFWXTx77aeOF5CAIAmbOK64SdMBJdNr6J41yP5mvQ==",
+      "requires": {
+        "@aws-crypto/ie11-detection": "^3.0.0",
+        "@aws-crypto/sha256-js": "^3.0.0",
+        "@aws-crypto/supports-web-crypto": "^3.0.0",
+        "@aws-crypto/util": "^3.0.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-crypto/sha256-js": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-3.0.0.tgz",
+      "integrity": "sha512-PnNN7os0+yd1XvXAy23CFOmTbMaDxgxXtTKHybrJ39Y8kGzBATgBFibWJKH6BhytLI/Zyszs87xCOBNyBig6vQ==",
+      "requires": {
+        "@aws-crypto/util": "^3.0.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-crypto/supports-web-crypto": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-3.0.0.tgz",
+      "integrity": "sha512-06hBdMwUAb2WFTuGG73LSC0wfPu93xWwo5vL2et9eymgmu3Id5vFAHBbajVWiGhPO37qcsdCap/FqXvJGJWPIg==",
+      "requires": {
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-crypto/util": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-3.0.0.tgz",
+      "integrity": "sha512-2OJlpeJpCR48CC8r+uKVChzs9Iungj9wkZrl8Z041DWEWvyIHILYKCPNzJghKsivj+S3mLo6BVc7mBNzdxA46w==",
+      "requires": {
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-sdk/client-lambda": {
+      "version": "3.485.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-lambda/-/client-lambda-3.485.0.tgz",
+      "integrity": "sha512-gaXn4Ps2L5OluV2tXzFUJ2up+iX2pm8XOyoq+RFS/NjLSQ66zKnrT4kBLuuntAPaj9ku6ag0+9ZUa6i6Zjx7qg==",
+      "requires": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/client-sts": "3.485.0",
+        "@aws-sdk/core": "3.485.0",
+        "@aws-sdk/credential-provider-node": "3.485.0",
+        "@aws-sdk/middleware-host-header": "3.485.0",
+        "@aws-sdk/middleware-logger": "3.485.0",
+        "@aws-sdk/middleware-recursion-detection": "3.485.0",
+        "@aws-sdk/middleware-signing": "3.485.0",
+        "@aws-sdk/middleware-user-agent": "3.485.0",
+        "@aws-sdk/region-config-resolver": "3.485.0",
+        "@aws-sdk/types": "3.485.0",
+        "@aws-sdk/util-endpoints": "3.485.0",
+        "@aws-sdk/util-user-agent-browser": "3.485.0",
+        "@aws-sdk/util-user-agent-node": "3.485.0",
+        "@smithy/config-resolver": "^2.0.23",
+        "@smithy/core": "^1.2.2",
+        "@smithy/eventstream-serde-browser": "^2.0.16",
+        "@smithy/eventstream-serde-config-resolver": "^2.0.16",
+        "@smithy/eventstream-serde-node": "^2.0.16",
+        "@smithy/fetch-http-handler": "^2.3.2",
+        "@smithy/hash-node": "^2.0.18",
+        "@smithy/invalid-dependency": "^2.0.16",
+        "@smithy/middleware-content-length": "^2.0.18",
+        "@smithy/middleware-endpoint": "^2.3.0",
+        "@smithy/middleware-retry": "^2.0.26",
+        "@smithy/middleware-serde": "^2.0.16",
+        "@smithy/middleware-stack": "^2.0.10",
+        "@smithy/node-config-provider": "^2.1.9",
+        "@smithy/node-http-handler": "^2.2.2",
+        "@smithy/protocol-http": "^3.0.12",
+        "@smithy/smithy-client": "^2.2.1",
+        "@smithy/types": "^2.8.0",
+        "@smithy/url-parser": "^2.0.16",
+        "@smithy/util-base64": "^2.0.1",
+        "@smithy/util-body-length-browser": "^2.0.1",
+        "@smithy/util-body-length-node": "^2.1.0",
+        "@smithy/util-defaults-mode-browser": "^2.0.24",
+        "@smithy/util-defaults-mode-node": "^2.0.32",
+        "@smithy/util-endpoints": "^1.0.8",
+        "@smithy/util-retry": "^2.0.9",
+        "@smithy/util-stream": "^2.0.24",
+        "@smithy/util-utf8": "^2.0.2",
+        "@smithy/util-waiter": "^2.0.16",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@aws-sdk/client-s3": {
+      "version": "3.485.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.485.0.tgz",
+      "integrity": "sha512-Vh8FRiXekwu1sSdfhS/wpNzjIljPmIXrUdEapR7EmaIwditR+mTTzNS+7y69YdPQhVEE2u9QxRlo4Eg1e1jD3w==",
+      "requires": {
+        "@aws-crypto/sha1-browser": "3.0.0",
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/client-sts": "3.485.0",
+        "@aws-sdk/core": "3.485.0",
+        "@aws-sdk/credential-provider-node": "3.485.0",
+        "@aws-sdk/middleware-bucket-endpoint": "3.485.0",
+        "@aws-sdk/middleware-expect-continue": "3.485.0",
+        "@aws-sdk/middleware-flexible-checksums": "3.485.0",
+        "@aws-sdk/middleware-host-header": "3.485.0",
+        "@aws-sdk/middleware-location-constraint": "3.485.0",
+        "@aws-sdk/middleware-logger": "3.485.0",
+        "@aws-sdk/middleware-recursion-detection": "3.485.0",
+        "@aws-sdk/middleware-sdk-s3": "3.485.0",
+        "@aws-sdk/middleware-signing": "3.485.0",
+        "@aws-sdk/middleware-ssec": "3.485.0",
+        "@aws-sdk/middleware-user-agent": "3.485.0",
+        "@aws-sdk/region-config-resolver": "3.485.0",
+        "@aws-sdk/signature-v4-multi-region": "3.485.0",
+        "@aws-sdk/types": "3.485.0",
+        "@aws-sdk/util-endpoints": "3.485.0",
+        "@aws-sdk/util-user-agent-browser": "3.485.0",
+        "@aws-sdk/util-user-agent-node": "3.485.0",
+        "@aws-sdk/xml-builder": "3.485.0",
+        "@smithy/config-resolver": "^2.0.23",
+        "@smithy/core": "^1.2.2",
+        "@smithy/eventstream-serde-browser": "^2.0.16",
+        "@smithy/eventstream-serde-config-resolver": "^2.0.16",
+        "@smithy/eventstream-serde-node": "^2.0.16",
+        "@smithy/fetch-http-handler": "^2.3.2",
+        "@smithy/hash-blob-browser": "^2.0.17",
+        "@smithy/hash-node": "^2.0.18",
+        "@smithy/hash-stream-node": "^2.0.18",
+        "@smithy/invalid-dependency": "^2.0.16",
+        "@smithy/md5-js": "^2.0.18",
+        "@smithy/middleware-content-length": "^2.0.18",
+        "@smithy/middleware-endpoint": "^2.3.0",
+        "@smithy/middleware-retry": "^2.0.26",
+        "@smithy/middleware-serde": "^2.0.16",
+        "@smithy/middleware-stack": "^2.0.10",
+        "@smithy/node-config-provider": "^2.1.9",
+        "@smithy/node-http-handler": "^2.2.2",
+        "@smithy/protocol-http": "^3.0.12",
+        "@smithy/smithy-client": "^2.2.1",
+        "@smithy/types": "^2.8.0",
+        "@smithy/url-parser": "^2.0.16",
+        "@smithy/util-base64": "^2.0.1",
+        "@smithy/util-body-length-browser": "^2.0.1",
+        "@smithy/util-body-length-node": "^2.1.0",
+        "@smithy/util-defaults-mode-browser": "^2.0.24",
+        "@smithy/util-defaults-mode-node": "^2.0.32",
+        "@smithy/util-endpoints": "^1.0.8",
+        "@smithy/util-retry": "^2.0.9",
+        "@smithy/util-stream": "^2.0.24",
+        "@smithy/util-utf8": "^2.0.2",
+        "@smithy/util-waiter": "^2.0.16",
+        "fast-xml-parser": "4.2.5",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@aws-sdk/client-secrets-manager": {
+      "version": "3.485.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.485.0.tgz",
+      "integrity": "sha512-TruRGEdTy1y/5ln1NcU5LvIZyK38O89zU9vCfNQIKwTSrpS0sDJQukjg8VfMC8gbqUUvXdiPcS61Fxr1WfWn7g==",
+      "requires": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/client-sts": "3.485.0",
+        "@aws-sdk/core": "3.485.0",
+        "@aws-sdk/credential-provider-node": "3.485.0",
+        "@aws-sdk/middleware-host-header": "3.485.0",
+        "@aws-sdk/middleware-logger": "3.485.0",
+        "@aws-sdk/middleware-recursion-detection": "3.485.0",
+        "@aws-sdk/middleware-signing": "3.485.0",
+        "@aws-sdk/middleware-user-agent": "3.485.0",
+        "@aws-sdk/region-config-resolver": "3.485.0",
+        "@aws-sdk/types": "3.485.0",
+        "@aws-sdk/util-endpoints": "3.485.0",
+        "@aws-sdk/util-user-agent-browser": "3.485.0",
+        "@aws-sdk/util-user-agent-node": "3.485.0",
+        "@smithy/config-resolver": "^2.0.23",
+        "@smithy/core": "^1.2.2",
+        "@smithy/fetch-http-handler": "^2.3.2",
+        "@smithy/hash-node": "^2.0.18",
+        "@smithy/invalid-dependency": "^2.0.16",
+        "@smithy/middleware-content-length": "^2.0.18",
+        "@smithy/middleware-endpoint": "^2.3.0",
+        "@smithy/middleware-retry": "^2.0.26",
+        "@smithy/middleware-serde": "^2.0.16",
+        "@smithy/middleware-stack": "^2.0.10",
+        "@smithy/node-config-provider": "^2.1.9",
+        "@smithy/node-http-handler": "^2.2.2",
+        "@smithy/protocol-http": "^3.0.12",
+        "@smithy/smithy-client": "^2.2.1",
+        "@smithy/types": "^2.8.0",
+        "@smithy/url-parser": "^2.0.16",
+        "@smithy/util-base64": "^2.0.1",
+        "@smithy/util-body-length-browser": "^2.0.1",
+        "@smithy/util-body-length-node": "^2.1.0",
+        "@smithy/util-defaults-mode-browser": "^2.0.24",
+        "@smithy/util-defaults-mode-node": "^2.0.32",
+        "@smithy/util-endpoints": "^1.0.8",
+        "@smithy/util-retry": "^2.0.9",
+        "@smithy/util-utf8": "^2.0.2",
+        "tslib": "^2.5.0",
+        "uuid": "^8.3.2"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "8.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+        }
+      }
+    },
+    "@aws-sdk/client-sfn": {
+      "version": "3.485.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sfn/-/client-sfn-3.485.0.tgz",
+      "integrity": "sha512-GImb0K0UO6nW+Ro8u1RTyv/Mu0m4X/jtTnm4vWbUV3xLosf4ru9WUJt0A8Gj3/HiTe3k9BrQoz7WQTpEY7bUtg==",
+      "requires": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/client-sts": "3.485.0",
+        "@aws-sdk/core": "3.485.0",
+        "@aws-sdk/credential-provider-node": "3.485.0",
+        "@aws-sdk/middleware-host-header": "3.485.0",
+        "@aws-sdk/middleware-logger": "3.485.0",
+        "@aws-sdk/middleware-recursion-detection": "3.485.0",
+        "@aws-sdk/middleware-signing": "3.485.0",
+        "@aws-sdk/middleware-user-agent": "3.485.0",
+        "@aws-sdk/region-config-resolver": "3.485.0",
+        "@aws-sdk/types": "3.485.0",
+        "@aws-sdk/util-endpoints": "3.485.0",
+        "@aws-sdk/util-user-agent-browser": "3.485.0",
+        "@aws-sdk/util-user-agent-node": "3.485.0",
+        "@smithy/config-resolver": "^2.0.23",
+        "@smithy/core": "^1.2.2",
+        "@smithy/fetch-http-handler": "^2.3.2",
+        "@smithy/hash-node": "^2.0.18",
+        "@smithy/invalid-dependency": "^2.0.16",
+        "@smithy/middleware-content-length": "^2.0.18",
+        "@smithy/middleware-endpoint": "^2.3.0",
+        "@smithy/middleware-retry": "^2.0.26",
+        "@smithy/middleware-serde": "^2.0.16",
+        "@smithy/middleware-stack": "^2.0.10",
+        "@smithy/node-config-provider": "^2.1.9",
+        "@smithy/node-http-handler": "^2.2.2",
+        "@smithy/protocol-http": "^3.0.12",
+        "@smithy/smithy-client": "^2.2.1",
+        "@smithy/types": "^2.8.0",
+        "@smithy/url-parser": "^2.0.16",
+        "@smithy/util-base64": "^2.0.1",
+        "@smithy/util-body-length-browser": "^2.0.1",
+        "@smithy/util-body-length-node": "^2.1.0",
+        "@smithy/util-defaults-mode-browser": "^2.0.24",
+        "@smithy/util-defaults-mode-node": "^2.0.32",
+        "@smithy/util-endpoints": "^1.0.8",
+        "@smithy/util-retry": "^2.0.9",
+        "@smithy/util-utf8": "^2.0.2",
+        "tslib": "^2.5.0",
+        "uuid": "^8.3.2"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "8.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+        }
+      }
+    },
+    "@aws-sdk/client-sso": {
+      "version": "3.485.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.485.0.tgz",
+      "integrity": "sha512-apN2bEn0PZs0jD4jAfvwO3dlWqw9YIQJ6TAudM1bd3S5vzWqlBBcLfQpK6taHoQaI+WqgUWXLuOf7gRFbGXKPg==",
+      "requires": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/core": "3.485.0",
+        "@aws-sdk/middleware-host-header": "3.485.0",
+        "@aws-sdk/middleware-logger": "3.485.0",
+        "@aws-sdk/middleware-recursion-detection": "3.485.0",
+        "@aws-sdk/middleware-user-agent": "3.485.0",
+        "@aws-sdk/region-config-resolver": "3.485.0",
+        "@aws-sdk/types": "3.485.0",
+        "@aws-sdk/util-endpoints": "3.485.0",
+        "@aws-sdk/util-user-agent-browser": "3.485.0",
+        "@aws-sdk/util-user-agent-node": "3.485.0",
+        "@smithy/config-resolver": "^2.0.23",
+        "@smithy/core": "^1.2.2",
+        "@smithy/fetch-http-handler": "^2.3.2",
+        "@smithy/hash-node": "^2.0.18",
+        "@smithy/invalid-dependency": "^2.0.16",
+        "@smithy/middleware-content-length": "^2.0.18",
+        "@smithy/middleware-endpoint": "^2.3.0",
+        "@smithy/middleware-retry": "^2.0.26",
+        "@smithy/middleware-serde": "^2.0.16",
+        "@smithy/middleware-stack": "^2.0.10",
+        "@smithy/node-config-provider": "^2.1.9",
+        "@smithy/node-http-handler": "^2.2.2",
+        "@smithy/protocol-http": "^3.0.12",
+        "@smithy/smithy-client": "^2.2.1",
+        "@smithy/types": "^2.8.0",
+        "@smithy/url-parser": "^2.0.16",
+        "@smithy/util-base64": "^2.0.1",
+        "@smithy/util-body-length-browser": "^2.0.1",
+        "@smithy/util-body-length-node": "^2.1.0",
+        "@smithy/util-defaults-mode-browser": "^2.0.24",
+        "@smithy/util-defaults-mode-node": "^2.0.32",
+        "@smithy/util-endpoints": "^1.0.8",
+        "@smithy/util-retry": "^2.0.9",
+        "@smithy/util-utf8": "^2.0.2",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@aws-sdk/client-sts": {
+      "version": "3.485.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.485.0.tgz",
+      "integrity": "sha512-PI4q36kVF0fpIPZyeQhrwwJZ6SRkOGvU3rX5Qn4b5UY5X+Ct1aLhqSX8/OB372UZIcnh6eSvERu8POHleDO7Jw==",
+      "requires": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/core": "3.485.0",
+        "@aws-sdk/credential-provider-node": "3.485.0",
+        "@aws-sdk/middleware-host-header": "3.485.0",
+        "@aws-sdk/middleware-logger": "3.485.0",
+        "@aws-sdk/middleware-recursion-detection": "3.485.0",
+        "@aws-sdk/middleware-user-agent": "3.485.0",
+        "@aws-sdk/region-config-resolver": "3.485.0",
+        "@aws-sdk/types": "3.485.0",
+        "@aws-sdk/util-endpoints": "3.485.0",
+        "@aws-sdk/util-user-agent-browser": "3.485.0",
+        "@aws-sdk/util-user-agent-node": "3.485.0",
+        "@smithy/config-resolver": "^2.0.23",
+        "@smithy/core": "^1.2.2",
+        "@smithy/fetch-http-handler": "^2.3.2",
+        "@smithy/hash-node": "^2.0.18",
+        "@smithy/invalid-dependency": "^2.0.16",
+        "@smithy/middleware-content-length": "^2.0.18",
+        "@smithy/middleware-endpoint": "^2.3.0",
+        "@smithy/middleware-retry": "^2.0.26",
+        "@smithy/middleware-serde": "^2.0.16",
+        "@smithy/middleware-stack": "^2.0.10",
+        "@smithy/node-config-provider": "^2.1.9",
+        "@smithy/node-http-handler": "^2.2.2",
+        "@smithy/protocol-http": "^3.0.12",
+        "@smithy/smithy-client": "^2.2.1",
+        "@smithy/types": "^2.8.0",
+        "@smithy/url-parser": "^2.0.16",
+        "@smithy/util-base64": "^2.0.1",
+        "@smithy/util-body-length-browser": "^2.0.1",
+        "@smithy/util-body-length-node": "^2.1.0",
+        "@smithy/util-defaults-mode-browser": "^2.0.24",
+        "@smithy/util-defaults-mode-node": "^2.0.32",
+        "@smithy/util-endpoints": "^1.0.8",
+        "@smithy/util-middleware": "^2.0.9",
+        "@smithy/util-retry": "^2.0.9",
+        "@smithy/util-utf8": "^2.0.2",
+        "fast-xml-parser": "4.2.5",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@aws-sdk/core": {
+      "version": "3.485.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.485.0.tgz",
+      "integrity": "sha512-Yvi80DQcbjkYCft471ClE3HuetuNVqntCs6eFOomDcrJaqdOFrXv2kJAxky84MRA/xb7bGlDGAPbTuj1ICputg==",
+      "requires": {
+        "@smithy/core": "^1.2.2",
+        "@smithy/protocol-http": "^3.0.12",
+        "@smithy/signature-v4": "^2.0.0",
+        "@smithy/smithy-client": "^2.2.1",
+        "@smithy/types": "^2.8.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@aws-sdk/credential-provider-env": {
+      "version": "3.485.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.485.0.tgz",
+      "integrity": "sha512-3XkFgwVU1XOB33dV7t9BKJ/ptdl2iS+0dxE7ecq8aqT2/gsfKmLCae1G17P8WmdD3z0kMDTvnqM2aWgUnSOkmg==",
+      "requires": {
+        "@aws-sdk/types": "3.485.0",
+        "@smithy/property-provider": "^2.0.0",
+        "@smithy/types": "^2.8.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@aws-sdk/credential-provider-ini": {
+      "version": "3.485.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.485.0.tgz",
+      "integrity": "sha512-cFYF/Bdw7EnT4viSxYpNIv3IBkri/Yb+JpQXl8uDq7bfVJfAN5qZmK07vRkg08xL6TC4F41wshhMSAucGdTwIw==",
+      "requires": {
+        "@aws-sdk/credential-provider-env": "3.485.0",
+        "@aws-sdk/credential-provider-process": "3.485.0",
+        "@aws-sdk/credential-provider-sso": "3.485.0",
+        "@aws-sdk/credential-provider-web-identity": "3.485.0",
+        "@aws-sdk/types": "3.485.0",
+        "@smithy/credential-provider-imds": "^2.0.0",
+        "@smithy/property-provider": "^2.0.0",
+        "@smithy/shared-ini-file-loader": "^2.0.6",
+        "@smithy/types": "^2.8.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@aws-sdk/credential-provider-node": {
+      "version": "3.485.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.485.0.tgz",
+      "integrity": "sha512-2DwzO2azkSzngifKDT61W/DL0tSzewuaFHiLJWdfc8Et3mdAQJ9x3KAj8u7XFpjIcGNqk7FiKjN+zeGUuNiEhA==",
+      "requires": {
+        "@aws-sdk/credential-provider-env": "3.485.0",
+        "@aws-sdk/credential-provider-ini": "3.485.0",
+        "@aws-sdk/credential-provider-process": "3.485.0",
+        "@aws-sdk/credential-provider-sso": "3.485.0",
+        "@aws-sdk/credential-provider-web-identity": "3.485.0",
+        "@aws-sdk/types": "3.485.0",
+        "@smithy/credential-provider-imds": "^2.0.0",
+        "@smithy/property-provider": "^2.0.0",
+        "@smithy/shared-ini-file-loader": "^2.0.6",
+        "@smithy/types": "^2.8.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@aws-sdk/credential-provider-process": {
+      "version": "3.485.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.485.0.tgz",
+      "integrity": "sha512-X9qS6ZO/rDKYDgWqD1YmSX7sAUUHax9HbXlgGiTTdtfhZvQh1ZmnH6wiPu5WNliafHZFtZT2W07kgrDLPld/Ug==",
+      "requires": {
+        "@aws-sdk/types": "3.485.0",
+        "@smithy/property-provider": "^2.0.0",
+        "@smithy/shared-ini-file-loader": "^2.0.6",
+        "@smithy/types": "^2.8.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@aws-sdk/credential-provider-sso": {
+      "version": "3.485.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.485.0.tgz",
+      "integrity": "sha512-l0oC8GTrWh+LFQQfSmG1Jai1PX7Mhj9arb/CaS1/tmeZE0hgIXW++tvljYs/Dds4LGXUlaWG+P7BrObf6OyIXA==",
+      "requires": {
+        "@aws-sdk/client-sso": "3.485.0",
+        "@aws-sdk/token-providers": "3.485.0",
+        "@aws-sdk/types": "3.485.0",
+        "@smithy/property-provider": "^2.0.0",
+        "@smithy/shared-ini-file-loader": "^2.0.6",
+        "@smithy/types": "^2.8.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@aws-sdk/credential-provider-web-identity": {
+      "version": "3.485.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.485.0.tgz",
+      "integrity": "sha512-WpBFZFE0iXtnibH5POMEKITj/hR0YV5l2n9p8BEvKjdJ63s3Xke1RN20ZdIyKDaRDwj8adnKDgNPEnAKdS4kLw==",
+      "requires": {
+        "@aws-sdk/types": "3.485.0",
+        "@smithy/property-provider": "^2.0.0",
+        "@smithy/types": "^2.8.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@aws-sdk/lib-storage": {
+      "version": "3.485.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/lib-storage/-/lib-storage-3.485.0.tgz",
+      "integrity": "sha512-d/DppujsMu2zg2K95wS2OZ+x+wY41OeZL0duROKZRzNtPyYzlOiSw00+zSz7/sdmUad1bYIEyDJ46zI/FV6AVg==",
+      "requires": {
+        "@smithy/abort-controller": "^2.0.1",
+        "@smithy/middleware-endpoint": "^2.3.0",
+        "@smithy/smithy-client": "^2.2.1",
+        "buffer": "5.6.0",
+        "events": "3.3.0",
+        "stream-browserify": "3.0.0",
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "buffer": {
+          "version": "5.6.0",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
+          "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
+          "requires": {
+            "base64-js": "^1.0.2",
+            "ieee754": "^1.1.4"
+          }
+        }
+      }
+    },
+    "@aws-sdk/middleware-bucket-endpoint": {
+      "version": "3.485.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.485.0.tgz",
+      "integrity": "sha512-DptPuprsx9V1LH91ZvC/7a7B1UnuSAIi1ArJHlHqJL1ISo6sH1oeXP6KRa0tj8biGMDIx0b22wg8EEpFePMy3w==",
+      "requires": {
+        "@aws-sdk/types": "3.485.0",
+        "@aws-sdk/util-arn-parser": "3.465.0",
+        "@smithy/node-config-provider": "^2.1.9",
+        "@smithy/protocol-http": "^3.0.12",
+        "@smithy/types": "^2.8.0",
+        "@smithy/util-config-provider": "^2.1.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@aws-sdk/middleware-expect-continue": {
+      "version": "3.485.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.485.0.tgz",
+      "integrity": "sha512-rOwJJWM1/ydwSiJJ1l/X5h91u2Xzb8/CwOW6ZY+E8iZA0HDCtlJnKNlhHb+NHGtDamd4+1qdGSRtPQevyS58Cg==",
+      "requires": {
+        "@aws-sdk/types": "3.485.0",
+        "@smithy/protocol-http": "^3.0.12",
+        "@smithy/types": "^2.8.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@aws-sdk/middleware-flexible-checksums": {
+      "version": "3.485.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.485.0.tgz",
+      "integrity": "sha512-5+OmVMbEwl1LDdWbaJxoSViw6vuMsdDQgASFUM37aG46q1zWSiPU171IXutEAFZZXN/t0HcOFi0AmNrS0o+dkQ==",
+      "requires": {
+        "@aws-crypto/crc32": "3.0.0",
+        "@aws-crypto/crc32c": "3.0.0",
+        "@aws-sdk/types": "3.485.0",
+        "@smithy/is-array-buffer": "^2.0.0",
+        "@smithy/protocol-http": "^3.0.12",
+        "@smithy/types": "^2.8.0",
+        "@smithy/util-utf8": "^2.0.2",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@aws-sdk/middleware-host-header": {
+      "version": "3.485.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.485.0.tgz",
+      "integrity": "sha512-1mAUX9dQNGo2RIKseVj7SI/D5abQJQ/Os8hQ0NyVAyyVYF+Yjx5PphKgfhM5yoBwuwZUl6q71XPYEGNx7be6SA==",
+      "requires": {
+        "@aws-sdk/types": "3.485.0",
+        "@smithy/protocol-http": "^3.0.12",
+        "@smithy/types": "^2.8.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@aws-sdk/middleware-location-constraint": {
+      "version": "3.485.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.485.0.tgz",
+      "integrity": "sha512-Mrp4chtYliqCUSVjzLYPcZCPGmhL4QM7o6NhHBdA6omaIGdn4pJqFwN5ELZoWJDZMKyfrKi6s6u97jR9VtEXRg==",
+      "requires": {
+        "@aws-sdk/types": "3.485.0",
+        "@smithy/types": "^2.8.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@aws-sdk/middleware-logger": {
+      "version": "3.485.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.485.0.tgz",
+      "integrity": "sha512-O8IgJ0LHi5wTs5GlpI7nqmmSSagkVdd1shpGgQWY2h0kMSCII8CJZHBG97dlFFpGTvx5EDlhPNek7rl/6F4dRw==",
+      "requires": {
+        "@aws-sdk/types": "3.485.0",
+        "@smithy/types": "^2.8.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@aws-sdk/middleware-recursion-detection": {
+      "version": "3.485.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.485.0.tgz",
+      "integrity": "sha512-ZeVNATGNFcqkWDut3luVszROTUzkU5u+rJpB/xmeMoenlDAjPRiHt/ca3WkI5wAnIJ1VSNGpD2sOFLMCH+EWag==",
+      "requires": {
+        "@aws-sdk/types": "3.485.0",
+        "@smithy/protocol-http": "^3.0.12",
+        "@smithy/types": "^2.8.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@aws-sdk/middleware-sdk-s3": {
+      "version": "3.485.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.485.0.tgz",
+      "integrity": "sha512-3769c4e3UtvaNU5T6dHxhjGI1kEXymldqiP1PMZMX2jVffwSGhbvyLq0Kl6+9Jr51fj2oXN6Tex+8J9+5dzTgQ==",
+      "requires": {
+        "@aws-sdk/types": "3.485.0",
+        "@aws-sdk/util-arn-parser": "3.465.0",
+        "@smithy/node-config-provider": "^2.1.9",
+        "@smithy/protocol-http": "^3.0.12",
+        "@smithy/signature-v4": "^2.0.0",
+        "@smithy/smithy-client": "^2.2.1",
+        "@smithy/types": "^2.8.0",
+        "@smithy/util-config-provider": "^2.1.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@aws-sdk/middleware-signing": {
+      "version": "3.485.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.485.0.tgz",
+      "integrity": "sha512-41xzT2p1sOibhsLkdE5rwPJkNbBtKD8Gp36/ySfu0KE415wfXKacElSVxAaBw39/j7iSWDYqqybeEYbAzk+3GQ==",
+      "requires": {
+        "@aws-sdk/types": "3.485.0",
+        "@smithy/property-provider": "^2.0.0",
+        "@smithy/protocol-http": "^3.0.12",
+        "@smithy/signature-v4": "^2.0.0",
+        "@smithy/types": "^2.8.0",
+        "@smithy/util-middleware": "^2.0.9",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@aws-sdk/middleware-ssec": {
+      "version": "3.485.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.485.0.tgz",
+      "integrity": "sha512-A59WTC0egT8zLnRzB+yWKq2AonugD1DgN4710RG70JY5XUmx5TYdECbUrVeG/zhNIKbBLLFjRcVk2uo4OZcgIA==",
+      "requires": {
+        "@aws-sdk/types": "3.485.0",
+        "@smithy/types": "^2.8.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@aws-sdk/middleware-user-agent": {
+      "version": "3.485.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.485.0.tgz",
+      "integrity": "sha512-CddCVOn+OPQ0CcchketIg+WF6v+MDLAf3GOYTR2htUxxIm7HABuRd6R3kvQ5Jny9CV8gMt22G1UZITsFexSJlQ==",
+      "requires": {
+        "@aws-sdk/types": "3.485.0",
+        "@aws-sdk/util-endpoints": "3.485.0",
+        "@smithy/protocol-http": "^3.0.12",
+        "@smithy/types": "^2.8.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@aws-sdk/region-config-resolver": {
+      "version": "3.485.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.485.0.tgz",
+      "integrity": "sha512-2FB2EQ0sIE+YgFqGtkE1lDIMIL6nYe6MkOHBwBM7bommadKIrbbr2L22bPZGs3ReTsxiJabjzxbuCAVhrpHmhg==",
+      "requires": {
+        "@smithy/node-config-provider": "^2.1.9",
+        "@smithy/types": "^2.8.0",
+        "@smithy/util-config-provider": "^2.1.0",
+        "@smithy/util-middleware": "^2.0.9",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@aws-sdk/s3-presigned-post": {
+      "version": "3.485.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/s3-presigned-post/-/s3-presigned-post-3.485.0.tgz",
+      "integrity": "sha512-uu6PmQaIMrdovePeQi+DHiVuQcW4EXDcNgaL+sUeZjzPXV1/nTROgW+msMRB9nmWMhdEaVCNLUgJDf73BsYY5A==",
+      "requires": {
+        "@aws-sdk/client-s3": "3.485.0",
+        "@aws-sdk/types": "3.485.0",
+        "@aws-sdk/util-format-url": "3.485.0",
+        "@smithy/middleware-endpoint": "^2.3.0",
+        "@smithy/signature-v4": "^2.0.0",
+        "@smithy/types": "^2.8.0",
+        "@smithy/util-hex-encoding": "^2.0.0",
+        "@smithy/util-utf8": "^2.0.2",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@aws-sdk/s3-request-presigner": {
+      "version": "3.485.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/s3-request-presigner/-/s3-request-presigner-3.485.0.tgz",
+      "integrity": "sha512-5TCyl1H/PdBH0XDSILb9y1d/fU+tDEQ7Fkqeb2gIYENDG09dX68TtcZVGs0sMZtC9CLUFpmEp8R/3LtfuoeY6w==",
+      "requires": {
+        "@aws-sdk/signature-v4-multi-region": "3.485.0",
+        "@aws-sdk/types": "3.485.0",
+        "@aws-sdk/util-format-url": "3.485.0",
+        "@smithy/middleware-endpoint": "^2.3.0",
+        "@smithy/protocol-http": "^3.0.12",
+        "@smithy/smithy-client": "^2.2.1",
+        "@smithy/types": "^2.8.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@aws-sdk/signature-v4-multi-region": {
+      "version": "3.485.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.485.0.tgz",
+      "integrity": "sha512-168ipXkbG75l9cKQmsBtx/4+AYjGsBoy724bXosW13t2/l/E3IzJAYUjDROiK0JXVMG85xAnGWbFwZkjxVXzrQ==",
+      "requires": {
+        "@aws-sdk/middleware-sdk-s3": "3.485.0",
+        "@aws-sdk/types": "3.485.0",
+        "@smithy/protocol-http": "^3.0.12",
+        "@smithy/signature-v4": "^2.0.0",
+        "@smithy/types": "^2.8.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@aws-sdk/token-providers": {
+      "version": "3.485.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.485.0.tgz",
+      "integrity": "sha512-kOXA1WKIVIFNRqHL8ynVZ3hCKLsgnEmGr2iDR6agDNw5fYIlCO/6N2xR6QdGcLTvUUbwOlz4OvKLUQnWMKAnnA==",
+      "requires": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/middleware-host-header": "3.485.0",
+        "@aws-sdk/middleware-logger": "3.485.0",
+        "@aws-sdk/middleware-recursion-detection": "3.485.0",
+        "@aws-sdk/middleware-user-agent": "3.485.0",
+        "@aws-sdk/region-config-resolver": "3.485.0",
+        "@aws-sdk/types": "3.485.0",
+        "@aws-sdk/util-endpoints": "3.485.0",
+        "@aws-sdk/util-user-agent-browser": "3.485.0",
+        "@aws-sdk/util-user-agent-node": "3.485.0",
+        "@smithy/config-resolver": "^2.0.23",
+        "@smithy/fetch-http-handler": "^2.3.2",
+        "@smithy/hash-node": "^2.0.18",
+        "@smithy/invalid-dependency": "^2.0.16",
+        "@smithy/middleware-content-length": "^2.0.18",
+        "@smithy/middleware-endpoint": "^2.3.0",
+        "@smithy/middleware-retry": "^2.0.26",
+        "@smithy/middleware-serde": "^2.0.16",
+        "@smithy/middleware-stack": "^2.0.10",
+        "@smithy/node-config-provider": "^2.1.9",
+        "@smithy/node-http-handler": "^2.2.2",
+        "@smithy/property-provider": "^2.0.0",
+        "@smithy/protocol-http": "^3.0.12",
+        "@smithy/shared-ini-file-loader": "^2.0.6",
+        "@smithy/smithy-client": "^2.2.1",
+        "@smithy/types": "^2.8.0",
+        "@smithy/url-parser": "^2.0.16",
+        "@smithy/util-base64": "^2.0.1",
+        "@smithy/util-body-length-browser": "^2.0.1",
+        "@smithy/util-body-length-node": "^2.1.0",
+        "@smithy/util-defaults-mode-browser": "^2.0.24",
+        "@smithy/util-defaults-mode-node": "^2.0.32",
+        "@smithy/util-endpoints": "^1.0.8",
+        "@smithy/util-retry": "^2.0.9",
+        "@smithy/util-utf8": "^2.0.2",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@aws-sdk/types": {
+      "version": "3.485.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.485.0.tgz",
+      "integrity": "sha512-+QW32YQdvZRDOwrAQPo/qCyXoSjgXB6RwJwCwkd8ebJXRXw6tmGKIHaZqYHt/LtBymvnaBgBBADNa4+qFvlOFw==",
+      "requires": {
+        "@smithy/types": "^2.8.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@aws-sdk/util-arn-parser": {
+      "version": "3.465.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.465.0.tgz",
+      "integrity": "sha512-zOJ82vzDJFqBX9yZBlNeHHrul/kpx/DCoxzW5UBbZeb26kfV53QhMSoEmY8/lEbBqlqargJ/sgRC845GFhHNQw==",
+      "requires": {
+        "tslib": "^2.5.0"
+      }
+    },
+    "@aws-sdk/util-endpoints": {
+      "version": "3.485.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.485.0.tgz",
+      "integrity": "sha512-dTd642F7nJisApF8YjniqQ6U59CP/DCtar11fXf1nG9YNBCBsNNVw5ZfZb5nSNzaIdy27mQioWTCV18JEj1mxg==",
+      "requires": {
+        "@aws-sdk/types": "3.485.0",
+        "@smithy/util-endpoints": "^1.0.8",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@aws-sdk/util-format-url": {
+      "version": "3.485.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-format-url/-/util-format-url-3.485.0.tgz",
+      "integrity": "sha512-CW82AQ8UD88jhI2OyAgT5yA8NH2KE0mgludRXYDT5uvwj6nlA7c2B+c2UJwbkMdlsUZip/XvN+jFoRR7AJH1GQ==",
+      "requires": {
+        "@aws-sdk/types": "3.485.0",
+        "@smithy/querystring-builder": "^2.0.16",
+        "@smithy/types": "^2.8.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@aws-sdk/util-locate-window": {
+      "version": "3.465.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.465.0.tgz",
+      "integrity": "sha512-f+QNcWGswredzC1ExNAB/QzODlxwaTdXkNT5cvke2RLX8SFU5pYk6h4uCtWC0vWPELzOfMfloBrJefBzlarhsw==",
+      "requires": {
+        "tslib": "^2.5.0"
+      }
+    },
+    "@aws-sdk/util-user-agent-browser": {
+      "version": "3.485.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.485.0.tgz",
+      "integrity": "sha512-QliWbjg0uOhGTcWgWTKPMY0SBi07g253DjwrCINT1auqDrdQPxa10xozpZExBYjAK2KuhYDNUzni127ae6MHOw==",
+      "requires": {
+        "@aws-sdk/types": "3.485.0",
+        "@smithy/types": "^2.8.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@aws-sdk/util-user-agent-node": {
+      "version": "3.485.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.485.0.tgz",
+      "integrity": "sha512-QF+aQ9jnDlPUlFBxBRqOylPf86xQuD3aEPpOErR+50qJawVvKa94uiAFdvtI9jv6hnRZmuFsTj2rsyytnbAYBA==",
+      "requires": {
+        "@aws-sdk/types": "3.485.0",
+        "@smithy/node-config-provider": "^2.1.9",
+        "@smithy/types": "^2.8.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@aws-sdk/util-utf8-browser": {
+      "version": "3.259.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.259.0.tgz",
+      "integrity": "sha512-UvFa/vR+e19XookZF8RzFZBrw2EUkQWxiBW0yYQAhvk3C+QVGl0H3ouca8LDBlBfQKXwmW3huo/59H8rwb1wJw==",
+      "requires": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/xml-builder": {
+      "version": "3.485.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.485.0.tgz",
+      "integrity": "sha512-xQexPM6LINOIkf3NLFywplcbApifZRMWFN41TDWYSNgCUa5uC9fntfenw8N/HTx1n+McRCWSAFBTjDqY/2OLCQ==",
+      "requires": {
+        "@smithy/types": "^2.8.0",
+        "tslib": "^2.5.0"
+      }
+    },
     "@babel/code-frame": {
       "version": "7.12.11",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
@@ -433,6 +1332,77 @@
       "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
       "dev": true
     },
+    "@janiscommerce/api-session": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@janiscommerce/api-session/-/api-session-3.4.0.tgz",
+      "integrity": "sha512-CNqlS3mpNdV55Isa572DNkOUAs1ClhaRovedkyuzTAydMhvlUakwqus0l2vu3RsrZHbV3teEWEPAPUz2UiPSFQ==",
+      "requires": {
+        "lllog": "^1.1.2"
+      }
+    },
+    "@janiscommerce/aws-secrets-manager": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@janiscommerce/aws-secrets-manager/-/aws-secrets-manager-1.1.0.tgz",
+      "integrity": "sha512-rDOYviPeWwrtEVUfIP3mJVmpbY8mzHZ6EUJgNeC9zqEhsIFRgrngDDDQvjpHdDoUJ25gVvUwoc84gN2S3eT6Mw==",
+      "requires": {
+        "@aws-sdk/client-secrets-manager": "^3.287.0"
+      }
+    },
+    "@janiscommerce/events": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@janiscommerce/events/-/events-0.2.0.tgz",
+      "integrity": "sha512-hRmJFZfUr+tDkH0Tdh/1QMfsUIYnWZ1uJnZj8Uf/RUSA6FkWWC1bXwGYLRJAhtkW11vbqjEe1iG28CuPsa7tmg=="
+    },
+    "@janiscommerce/lambda": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@janiscommerce/lambda/-/lambda-6.1.0.tgz",
+      "integrity": "sha512-TTfA8rOP+1tbJqXEsDNP7IdlzzROBBOa2l2RkSjI7x+bC1bj21SZGrkhpqYQpYUOay0JlYE55dojGC/JiJ/WIA==",
+      "requires": {
+        "@aws-sdk/client-lambda": "^3.288.0",
+        "@aws-sdk/client-sfn": "^3.288.0",
+        "@aws-sdk/client-sts": "^3.288.0",
+        "@janiscommerce/api-session": "^3.3.1",
+        "@janiscommerce/aws-secrets-manager": "^1.0.2",
+        "@janiscommerce/events": "^0.2.0",
+        "@janiscommerce/router-fetcher": "^2.1.2",
+        "@janiscommerce/s3": "^2.0.0",
+        "lllog": "^1.1.2",
+        "lodash": "^4.17.21",
+        "nanoid": "^3.3.4"
+      },
+      "dependencies": {
+        "nanoid": {
+          "version": "3.3.7",
+          "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
+          "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g=="
+        }
+      }
+    },
+    "@janiscommerce/router-fetcher": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@janiscommerce/router-fetcher/-/router-fetcher-2.1.2.tgz",
+      "integrity": "sha512-mT+MCPygKjxGa16vmFJD9UfAiSQehXrAkqRdjH38mU1qztGQHhNFrW//w5kAoB5st2q6qIBuDag43y0smjJ1Hw==",
+      "requires": {
+        "@janiscommerce/settings": "^1.0.1",
+        "axios": "^0.24.0"
+      }
+    },
+    "@janiscommerce/s3": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@janiscommerce/s3/-/s3-2.0.2.tgz",
+      "integrity": "sha512-ITZ/he3RyN+T3gyKoaWPUEERn20UiztqGKDYNY5wTtzXdt7SpFMC+zp389Yw9VYILSA12bzTDzDOnuCvv0kxuA==",
+      "requires": {
+        "@aws-sdk/client-s3": "^3.350.0",
+        "@aws-sdk/lib-storage": "^3.350.0",
+        "@aws-sdk/s3-presigned-post": "^3.350.0",
+        "@aws-sdk/s3-request-presigner": "^3.350.0"
+      }
+    },
+    "@janiscommerce/settings": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@janiscommerce/settings/-/settings-1.0.1.tgz",
+      "integrity": "sha512-BzB+m4+WYGhHepRxysW9i0Ndq6/5pAZEnPjHBM1BcgQ0WXUwhjyzPu3+lDJv9V9eUeaUNA4XcOTxYGNW78xBig=="
+    },
     "@sinonjs/commons": {
       "version": "1.8.3",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.3.tgz",
@@ -467,6 +1437,527 @@
       "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
       "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
       "dev": true
+    },
+    "@smithy/abort-controller": {
+      "version": "2.0.16",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-2.0.16.tgz",
+      "integrity": "sha512-4foO7738k8kM9flMHu3VLabqu7nPgvIj8TB909S0CnKx0YZz/dcDH3pZ/4JHdatfxlZdKF1JWOYCw9+v3HVVsw==",
+      "requires": {
+        "@smithy/types": "^2.8.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/chunked-blob-reader": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/chunked-blob-reader/-/chunked-blob-reader-2.0.0.tgz",
+      "integrity": "sha512-k+J4GHJsMSAIQPChGBrjEmGS+WbPonCXesoqP9fynIqjn7rdOThdH8FAeCmokP9mxTYKQAKoHCLPzNlm6gh7Wg==",
+      "requires": {
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/chunked-blob-reader-native": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/chunked-blob-reader-native/-/chunked-blob-reader-native-2.0.1.tgz",
+      "integrity": "sha512-N2oCZRglhWKm7iMBu7S6wDzXirjAofi7tAd26cxmgibRYOBS4D3hGfmkwCpHdASZzwZDD8rluh0Rcqw1JeZDRw==",
+      "requires": {
+        "@smithy/util-base64": "^2.0.1",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/config-resolver": {
+      "version": "2.0.23",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-2.0.23.tgz",
+      "integrity": "sha512-XakUqgtP2YY8Mi+Nlif5BiqJgWdvfxJafSpOSQeCOMizu+PUhE4fBQSy6xFcR+eInrwVadaABNxoJyGUMn15ew==",
+      "requires": {
+        "@smithy/node-config-provider": "^2.1.9",
+        "@smithy/types": "^2.8.0",
+        "@smithy/util-config-provider": "^2.1.0",
+        "@smithy/util-middleware": "^2.0.9",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/core": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-1.2.2.tgz",
+      "integrity": "sha512-uLjrskLT+mWb0emTR5QaiAIxVEU7ndpptDaVDrTwwhD+RjvHhjIiGQ3YL5jKk1a5VSDQUA2RGkXvJ6XKRcz6Dg==",
+      "requires": {
+        "@smithy/middleware-endpoint": "^2.3.0",
+        "@smithy/middleware-retry": "^2.0.26",
+        "@smithy/middleware-serde": "^2.0.16",
+        "@smithy/protocol-http": "^3.0.12",
+        "@smithy/smithy-client": "^2.2.1",
+        "@smithy/types": "^2.8.0",
+        "@smithy/util-middleware": "^2.0.9",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/credential-provider-imds": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-2.1.5.tgz",
+      "integrity": "sha512-VfvE6Wg1MUWwpTZFBnUD7zxvPhLY8jlHCzu6bCjlIYoWgXCDzZAML76IlZUEf45nib3rjehnFgg0s1rgsuN/bg==",
+      "requires": {
+        "@smithy/node-config-provider": "^2.1.9",
+        "@smithy/property-provider": "^2.0.17",
+        "@smithy/types": "^2.8.0",
+        "@smithy/url-parser": "^2.0.16",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/eventstream-codec": {
+      "version": "2.0.16",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-2.0.16.tgz",
+      "integrity": "sha512-umYh5pdCE9GHgiMAH49zu9wXWZKNHHdKPm/lK22WYISTjqu29SepmpWNmPiBLy/yUu4HFEGJHIFrDWhbDlApaw==",
+      "requires": {
+        "@aws-crypto/crc32": "3.0.0",
+        "@smithy/types": "^2.8.0",
+        "@smithy/util-hex-encoding": "^2.0.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/eventstream-serde-browser": {
+      "version": "2.0.16",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-2.0.16.tgz",
+      "integrity": "sha512-W+BdiN728R57KuZOcG0GczpIOEFf8S5RP/OdVH7T3FMCy8HU2bBU0vB5xZZR5c00VRdoeWrohNv3XlHoZuGRoA==",
+      "requires": {
+        "@smithy/eventstream-serde-universal": "^2.0.16",
+        "@smithy/types": "^2.8.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/eventstream-serde-config-resolver": {
+      "version": "2.0.16",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-2.0.16.tgz",
+      "integrity": "sha512-8qrE4nh+Tg6m1SMFK8vlzoK+8bUFTlIhXidmmQfASMninXW3Iu0T0bI4YcIk4nLznHZdybQ0qGydIanvVZxzVg==",
+      "requires": {
+        "@smithy/types": "^2.8.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/eventstream-serde-node": {
+      "version": "2.0.16",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-2.0.16.tgz",
+      "integrity": "sha512-NRNQuOa6mQdFSkqzY0IV37swHWx0SEoKxFtUfdZvfv0AVQPlSw4N7E3kcRSCpnHBr1kCuWWirdDlWcjWuD81MA==",
+      "requires": {
+        "@smithy/eventstream-serde-universal": "^2.0.16",
+        "@smithy/types": "^2.8.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/eventstream-serde-universal": {
+      "version": "2.0.16",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-2.0.16.tgz",
+      "integrity": "sha512-ZyLnGaYQMLc75j9kKEVMJ3X6bdBE9qWxhZdTXM5RIltuytxJC3FaOhawBxjE+IL1enmWSIohHGZCm/pLwEliQA==",
+      "requires": {
+        "@smithy/eventstream-codec": "^2.0.16",
+        "@smithy/types": "^2.8.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/fetch-http-handler": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-2.3.2.tgz",
+      "integrity": "sha512-O9R/OlnAOTsnysuSDjt0v2q6DcSvCz5cCFC/CFAWWcLyBwJDeFyGTCTszgpQTb19+Fi8uRwZE5/3ziAQBFeDMQ==",
+      "requires": {
+        "@smithy/protocol-http": "^3.0.12",
+        "@smithy/querystring-builder": "^2.0.16",
+        "@smithy/types": "^2.8.0",
+        "@smithy/util-base64": "^2.0.1",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/hash-blob-browser": {
+      "version": "2.0.17",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-blob-browser/-/hash-blob-browser-2.0.17.tgz",
+      "integrity": "sha512-/mPpv1sRiRDdjO4zZuO8be6eeabmg5AVgKDfnmmqkpBtRyMGSJb968fjRuHt+FRAsIGywgIKJFmUUAYjhsi1oQ==",
+      "requires": {
+        "@smithy/chunked-blob-reader": "^2.0.0",
+        "@smithy/chunked-blob-reader-native": "^2.0.1",
+        "@smithy/types": "^2.8.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/hash-node": {
+      "version": "2.0.18",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-2.0.18.tgz",
+      "integrity": "sha512-gN2JFvAgnZCyDN9rJgcejfpK0uPPJrSortVVVVWsru9whS7eQey6+gj2eM5ln2i6rHNntIXzal1Fm9XOPuoaKA==",
+      "requires": {
+        "@smithy/types": "^2.8.0",
+        "@smithy/util-buffer-from": "^2.0.0",
+        "@smithy/util-utf8": "^2.0.2",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/hash-stream-node": {
+      "version": "2.0.18",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-stream-node/-/hash-stream-node-2.0.18.tgz",
+      "integrity": "sha512-OuFk+ITpv8CtxGjQcS8GA04faNycu9UMm6YobvQzjeEoXZ0dLF6sRfuzD+3S8RHPKpTyLuXtKG1+GiJycZ5TcA==",
+      "requires": {
+        "@smithy/types": "^2.8.0",
+        "@smithy/util-utf8": "^2.0.2",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/invalid-dependency": {
+      "version": "2.0.16",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-2.0.16.tgz",
+      "integrity": "sha512-apEHakT/kmpNo1VFHP4W/cjfeP9U0x5qvfsLJubgp7UM/gq4qYp0GbqdE7QhsjUaYvEnrftRqs7+YrtWreV0wA==",
+      "requires": {
+        "@smithy/types": "^2.8.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/is-array-buffer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.0.0.tgz",
+      "integrity": "sha512-z3PjFjMyZNI98JFRJi/U0nGoLWMSJlDjAW4QUX2WNZLas5C0CmVV6LJ01JI0k90l7FvpmixjWxPFmENSClQ7ug==",
+      "requires": {
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/md5-js": {
+      "version": "2.0.18",
+      "resolved": "https://registry.npmjs.org/@smithy/md5-js/-/md5-js-2.0.18.tgz",
+      "integrity": "sha512-bHwZ8/m6RbERQdVW5rJ2LzeW8qxfXv6Q/S7Fiudhso4pWRrksqLx3nsGZw7bmqqfN4zLqkxydxSa9+4c7s5zxg==",
+      "requires": {
+        "@smithy/types": "^2.8.0",
+        "@smithy/util-utf8": "^2.0.2",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/middleware-content-length": {
+      "version": "2.0.18",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-2.0.18.tgz",
+      "integrity": "sha512-ZJ9uKPTfxYheTKSKYB+GCvcj+izw9WGzRLhjn8n254q0jWLojUzn7Vw0l4R/Gq7Wdpf/qmk/ptD+6CCXHNVCaw==",
+      "requires": {
+        "@smithy/protocol-http": "^3.0.12",
+        "@smithy/types": "^2.8.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/middleware-endpoint": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-2.3.0.tgz",
+      "integrity": "sha512-VsOAG2YQ8ykjSmKO+CIXdJBIWFo6AAvG6Iw95BakBTqk66/4BI7XyqLevoNSq/lZ6NgZv24sLmrcIN+fLDWBCg==",
+      "requires": {
+        "@smithy/middleware-serde": "^2.0.16",
+        "@smithy/node-config-provider": "^2.1.9",
+        "@smithy/shared-ini-file-loader": "^2.2.8",
+        "@smithy/types": "^2.8.0",
+        "@smithy/url-parser": "^2.0.16",
+        "@smithy/util-middleware": "^2.0.9",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/middleware-retry": {
+      "version": "2.0.26",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-2.0.26.tgz",
+      "integrity": "sha512-Qzpxo0U5jfNiq9iD38U3e2bheXwvTEX4eue9xruIvEgh+UKq6dKuGqcB66oBDV7TD/mfoJi9Q/VmaiqwWbEp7A==",
+      "requires": {
+        "@smithy/node-config-provider": "^2.1.9",
+        "@smithy/protocol-http": "^3.0.12",
+        "@smithy/service-error-classification": "^2.0.9",
+        "@smithy/smithy-client": "^2.2.1",
+        "@smithy/types": "^2.8.0",
+        "@smithy/util-middleware": "^2.0.9",
+        "@smithy/util-retry": "^2.0.9",
+        "tslib": "^2.5.0",
+        "uuid": "^8.3.2"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "8.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+        }
+      }
+    },
+    "@smithy/middleware-serde": {
+      "version": "2.0.16",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-2.0.16.tgz",
+      "integrity": "sha512-5EAd4t30pcc4M8TSSGq7q/x5IKrxfXR5+SrU4bgxNy7RPHQo2PSWBUco9C+D9Tfqp/JZvprRpK42dnupZafk2g==",
+      "requires": {
+        "@smithy/types": "^2.8.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/middleware-stack": {
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-2.0.10.tgz",
+      "integrity": "sha512-I2rbxctNq9FAPPEcuA1ntZxkTKOPQFy7YBPOaD/MLg1zCvzv21CoNxR0py6J8ZVC35l4qE4nhxB0f7TF5/+Ldw==",
+      "requires": {
+        "@smithy/types": "^2.8.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/node-config-provider": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-2.1.9.tgz",
+      "integrity": "sha512-tUyW/9xrRy+s7RXkmQhgYkAPMpTIF8izK4orhHjNFEKR3QZiOCbWB546Y8iB/Fpbm3O9+q0Af9rpywLKJOwtaQ==",
+      "requires": {
+        "@smithy/property-provider": "^2.0.17",
+        "@smithy/shared-ini-file-loader": "^2.2.8",
+        "@smithy/types": "^2.8.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/node-http-handler": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-2.2.2.tgz",
+      "integrity": "sha512-XO58TO/Eul/IBQKFKaaBtXJi0ItEQQCT+NI4IiKHCY/4KtqaUT6y/wC1EvDqlA9cP7Dyjdj7FdPs4DyynH3u7g==",
+      "requires": {
+        "@smithy/abort-controller": "^2.0.16",
+        "@smithy/protocol-http": "^3.0.12",
+        "@smithy/querystring-builder": "^2.0.16",
+        "@smithy/types": "^2.8.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/property-provider": {
+      "version": "2.0.17",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-2.0.17.tgz",
+      "integrity": "sha512-+VkeZbVu7qtQ2DjI48Qwaf9fPOr3gZIwxQpuLJgRRSkWsdSvmaTCxI3gzRFKePB63Ts9r4yjn4HkxSCSkdWmcQ==",
+      "requires": {
+        "@smithy/types": "^2.8.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/protocol-http": {
+      "version": "3.0.12",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-3.0.12.tgz",
+      "integrity": "sha512-Xz4iaqLiaBfbQpB9Hgi3VcZYbP7xRDXYhd8XWChh4v94uw7qwmvlxdU5yxzfm6ACJM66phHrTbS5TVvj5uQ72w==",
+      "requires": {
+        "@smithy/types": "^2.8.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/querystring-builder": {
+      "version": "2.0.16",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-2.0.16.tgz",
+      "integrity": "sha512-Q/GsJT0C0mijXMRs7YhZLLCP5FcuC4797lYjKQkME5CZohnLC4bEhylAd2QcD3gbMKNjCw8+T2I27WKiV/wToA==",
+      "requires": {
+        "@smithy/types": "^2.8.0",
+        "@smithy/util-uri-escape": "^2.0.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/querystring-parser": {
+      "version": "2.0.16",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-2.0.16.tgz",
+      "integrity": "sha512-c4ueAuL6BDYKWpkubjrQthZKoC3L5kql5O++ovekNxiexRXTlLIVlCR4q3KziOktLIw66EU9SQljPXd/oN6Okg==",
+      "requires": {
+        "@smithy/types": "^2.8.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/service-error-classification": {
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-2.0.9.tgz",
+      "integrity": "sha512-0K+8GvtwI7VkGmmInPydM2XZyBfIqLIbfR7mDQ+oPiz8mIinuHbV6sxOLdvX1Jv/myk7XTK9orgt3tuEpBu/zg==",
+      "requires": {
+        "@smithy/types": "^2.8.0"
+      }
+    },
+    "@smithy/shared-ini-file-loader": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-2.2.8.tgz",
+      "integrity": "sha512-E62byatbwSWrtq9RJ7xN40tqrRKDGrEL4EluyNpaIDvfvet06a/QC58oHw2FgVaEgkj0tXZPjZaKrhPfpoU0qw==",
+      "requires": {
+        "@smithy/types": "^2.8.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/signature-v4": {
+      "version": "2.0.19",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-2.0.19.tgz",
+      "integrity": "sha512-nwc3JihdM+kcJjtORv/n7qRHN2Kfh7S2RJI2qr8pz9UcY5TD8rSCRGQ0g81HgyS3jZ5X9U/L4p014P3FonBPhg==",
+      "requires": {
+        "@smithy/eventstream-codec": "^2.0.16",
+        "@smithy/is-array-buffer": "^2.0.0",
+        "@smithy/types": "^2.8.0",
+        "@smithy/util-hex-encoding": "^2.0.0",
+        "@smithy/util-middleware": "^2.0.9",
+        "@smithy/util-uri-escape": "^2.0.0",
+        "@smithy/util-utf8": "^2.0.2",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/smithy-client": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-2.2.1.tgz",
+      "integrity": "sha512-SpD7FLK92XV2fon2hMotaNDa2w5VAy5/uVjP9WFmjGSgWM8pTPVkHcDl1yFs5Z8LYbij0FSz+DbCBK6i+uXXUA==",
+      "requires": {
+        "@smithy/middleware-endpoint": "^2.3.0",
+        "@smithy/middleware-stack": "^2.0.10",
+        "@smithy/protocol-http": "^3.0.12",
+        "@smithy/types": "^2.8.0",
+        "@smithy/util-stream": "^2.0.24",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/types": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.8.0.tgz",
+      "integrity": "sha512-h9sz24cFgt/W1Re22OlhQKmUZkNh244ApgRsUDYinqF8R+QgcsBIX344u2j61TPshsTz3CvL6HYU1DnQdsSrHA==",
+      "requires": {
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/url-parser": {
+      "version": "2.0.16",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-2.0.16.tgz",
+      "integrity": "sha512-Wfz5WqAoRT91TjRy1JeLR0fXtkIXHGsMbgzKFTx7E68SrZ55TB8xoG+vm11Ru4gheFTMXjAjwAxv1jQdC+pAQA==",
+      "requires": {
+        "@smithy/querystring-parser": "^2.0.16",
+        "@smithy/types": "^2.8.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/util-base64": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-2.0.1.tgz",
+      "integrity": "sha512-DlI6XFYDMsIVN+GH9JtcRp3j02JEVuWIn/QOZisVzpIAprdsxGveFed0bjbMRCqmIFe8uetn5rxzNrBtIGrPIQ==",
+      "requires": {
+        "@smithy/util-buffer-from": "^2.0.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/util-body-length-browser": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-2.0.1.tgz",
+      "integrity": "sha512-NXYp3ttgUlwkaug4bjBzJ5+yIbUbUx8VsSLuHZROQpoik+gRkIBeEG9MPVYfvPNpuXb/puqodeeUXcKFe7BLOQ==",
+      "requires": {
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/util-body-length-node": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-2.1.0.tgz",
+      "integrity": "sha512-/li0/kj/y3fQ3vyzn36NTLGmUwAICb7Jbe/CsWCktW363gh1MOcpEcSO3mJ344Gv2dqz8YJCLQpb6hju/0qOWw==",
+      "requires": {
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/util-buffer-from": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.0.0.tgz",
+      "integrity": "sha512-/YNnLoHsR+4W4Vf2wL5lGv0ksg8Bmk3GEGxn2vEQt52AQaPSCuaO5PM5VM7lP1K9qHRKHwrPGktqVoAHKWHxzw==",
+      "requires": {
+        "@smithy/is-array-buffer": "^2.0.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/util-config-provider": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-2.1.0.tgz",
+      "integrity": "sha512-S6V0JvvhQgFSGLcJeT1CBsaTR03MM8qTuxMH9WPCCddlSo2W0V5jIHimHtIQALMLEDPGQ0ROSRr/dU0O+mxiQg==",
+      "requires": {
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/util-defaults-mode-browser": {
+      "version": "2.0.24",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-2.0.24.tgz",
+      "integrity": "sha512-TsP5mBuLgO2C21+laNG2nHYZEyUdkbGURv2tHvSuQQxLz952MegX95uwdxOY2jR2H4GoKuVRfdJq7w4eIjGYeg==",
+      "requires": {
+        "@smithy/property-provider": "^2.0.17",
+        "@smithy/smithy-client": "^2.2.1",
+        "@smithy/types": "^2.8.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/util-defaults-mode-node": {
+      "version": "2.0.32",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-2.0.32.tgz",
+      "integrity": "sha512-d0S33dXA2cq1NyorVMroMrEtqKMr3MlyLITcfTBf9pXiigYiPMOtbSI7czHIfDbuVuM89Cg0urAgpt73QV9mPQ==",
+      "requires": {
+        "@smithy/config-resolver": "^2.0.23",
+        "@smithy/credential-provider-imds": "^2.1.5",
+        "@smithy/node-config-provider": "^2.1.9",
+        "@smithy/property-provider": "^2.0.17",
+        "@smithy/smithy-client": "^2.2.1",
+        "@smithy/types": "^2.8.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/util-endpoints": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-1.0.8.tgz",
+      "integrity": "sha512-l8zVuyZZ61IzZBYp5NWvsAhbaAjYkt0xg9R4xUASkg5SEeTT2meHOJwJHctKMFUXe4QZbn9fR2MaBYjP2119+w==",
+      "requires": {
+        "@smithy/node-config-provider": "^2.1.9",
+        "@smithy/types": "^2.8.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/util-hex-encoding": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-2.0.0.tgz",
+      "integrity": "sha512-c5xY+NUnFqG6d7HFh1IFfrm3mGl29lC+vF+geHv4ToiuJCBmIfzx6IeHLg+OgRdPFKDXIw6pvi+p3CsscaMcMA==",
+      "requires": {
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/util-middleware": {
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-2.0.9.tgz",
+      "integrity": "sha512-PnCnBJ07noMX1lMDTEefmxSlusWJUiLfrme++MfK5TD0xz8NYmakgoXy5zkF/16zKGmiwOeKAztWT/Vjk1KRIQ==",
+      "requires": {
+        "@smithy/types": "^2.8.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/util-retry": {
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-2.0.9.tgz",
+      "integrity": "sha512-46BFWe9RqB6g7f4mxm3W3HlqknqQQmWHKlhoqSFZuGNuiDU5KqmpebMbvC3tjTlUkqn4xa2Z7s3Hwb0HNs5scw==",
+      "requires": {
+        "@smithy/service-error-classification": "^2.0.9",
+        "@smithy/types": "^2.8.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/util-stream": {
+      "version": "2.0.24",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-2.0.24.tgz",
+      "integrity": "sha512-hRpbcRrOxDriMVmbya+Mv77VZVupxRAsfxVDKS54XuiURhdiwCUXJP0X1iJhHinuUf6n8pBF0MkG9C8VooMnWw==",
+      "requires": {
+        "@smithy/fetch-http-handler": "^2.3.2",
+        "@smithy/node-http-handler": "^2.2.2",
+        "@smithy/types": "^2.8.0",
+        "@smithy/util-base64": "^2.0.1",
+        "@smithy/util-buffer-from": "^2.0.0",
+        "@smithy/util-hex-encoding": "^2.0.0",
+        "@smithy/util-utf8": "^2.0.2",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/util-uri-escape": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-2.0.0.tgz",
+      "integrity": "sha512-ebkxsqinSdEooQduuk9CbKcI+wheijxEb3utGXkCoYQkJnwTnLbH1JXGimJtUkQwNQbsbuYwG2+aFVyZf5TLaw==",
+      "requires": {
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/util-utf8": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.0.2.tgz",
+      "integrity": "sha512-qOiVORSPm6Ce4/Yu6hbSgNHABLP2VMv8QOC3tTDNHHlWY19pPyc++fBTbZPtx6egPXi4HQxKDnMxVxpbtX2GoA==",
+      "requires": {
+        "@smithy/util-buffer-from": "^2.0.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/util-waiter": {
+      "version": "2.0.16",
+      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-2.0.16.tgz",
+      "integrity": "sha512-5i4YONHQ6HoUWDd+X0frpxTXxSXgJhUFl+z0iMy/zpUmVeCQY2or3Vss6DzHKKMMQL4pmVHpQm9WayHDorFdZg==",
+      "requires": {
+        "@smithy/abort-controller": "^2.0.16",
+        "@smithy/types": "^2.8.0",
+        "tslib": "^2.5.0"
+      }
     },
     "@ungap/promise-all-settled": {
       "version": "1.1.2",
@@ -592,6 +2083,14 @@
       "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
       "dev": true
     },
+    "axios": {
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.24.0.tgz",
+      "integrity": "sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==",
+      "requires": {
+        "follow-redirects": "^1.14.4"
+      }
+    },
     "balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -608,6 +2107,11 @@
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
       "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
       "dev": true
+    },
+    "bowser": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
+      "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA=="
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -1305,6 +2809,11 @@
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true
     },
+    "events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q=="
+    },
     "fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -1322,6 +2831,14 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
+    },
+    "fast-xml-parser": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.5.tgz",
+      "integrity": "sha512-B9/wizE4WngqQftFPmdaMYlXoJlJOYxGQOanC77fq9k8+Z0v5dDSVh+3glErdIROP//s/jgb7ZuxKfB8nVyo0g==",
+      "requires": {
+        "strnum": "^1.0.5"
+      }
     },
     "file-entry-cache": {
       "version": "6.0.1",
@@ -1442,6 +2959,11 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.2.tgz",
       "integrity": "sha512-JaTY/wtrcSyvXJl4IMFHPKyFur1sE9AUqc0QnhOaJ0CxHtAoIV8pYDzeEfAaNEtGkOfq4gr3LBFmdXW5mOQFnA==",
       "dev": true
+    },
+    "follow-redirects": {
+      "version": "1.15.4",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.4.tgz",
+      "integrity": "sha512-Cr4D/5wlrb0z9dgERpUL3LrmPKVDsETIJhaCMeDfuFYcqa5bldGV6wBsAN6X/vxlXQtFBMrXdXxdL8CbDTGniw=="
     },
     "foreground-child": {
       "version": "2.0.0",
@@ -1699,8 +3221,7 @@
     "inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "internal-slot": {
       "version": "1.0.3",
@@ -2080,6 +3601,11 @@
         "p-locate": "^2.0.0",
         "path-exists": "^3.0.0"
       }
+    },
+    "lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "lodash.clonedeep": {
       "version": "4.5.0",
@@ -2968,6 +4494,16 @@
         "read-pkg": "^3.0.0"
       }
     },
+    "readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "requires": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      }
+    },
     "readdirp": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
@@ -3036,8 +4572,7 @@
     "safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "dev": true
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
     },
     "semver": {
       "version": "5.7.1",
@@ -3217,6 +4752,15 @@
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
+    "stream-browserify": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-3.0.0.tgz",
+      "integrity": "sha512-H73RAHsVBapbim0tU2JwwOiXUj+fikfiaoYAKHF3VJfA0pe2BCzkhAHBlLG6REzE+2WNZcxOXjK7lkso+9euLA==",
+      "requires": {
+        "inherits": "~2.0.4",
+        "readable-stream": "^3.5.0"
+      }
+    },
     "string-width": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
@@ -3248,6 +4792,14 @@
         "define-properties": "^1.1.3"
       }
     },
+    "string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "requires": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
     "strip-ansi": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
@@ -3268,6 +4820,11 @@
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
       "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
       "dev": true
+    },
+    "strnum": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
+      "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA=="
     },
     "supports-color": {
       "version": "5.5.0",
@@ -3355,6 +4912,11 @@
         "strip-bom": "^3.0.0"
       }
     },
+    "tslib": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+    },
     "type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -3417,6 +4979,11 @@
       "requires": {
         "punycode": "^2.1.0"
       }
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
     "uuid": {
       "version": "3.4.0",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "test": "tests"
   },
   "dependencies": {
+    "@janiscommerce/lambda": "^6.1.0",
     "bwip-js": "^3.0.4",
     "date-fns": "^2.28.0",
     "date-fns-tz": "^1.3.3",

--- a/tests/handlebars-helpers-test.js
+++ b/tests/handlebars-helpers-test.js
@@ -1671,10 +1671,10 @@ describe('Handlebars Helpers', () => {
 			assert.strictEqual(templateCompiled(values), '<html><body><h1></h1></body></html>');
 		});
 
-		const otherTemplate = '<html><body><h1>{{shortLink "https://janis.im"}}</h1></body></html>';
-		const otherTemplateCompiled = Handlebars.compile(otherTemplate, 'strict');
-
 		it('Should return template with value in string if value is number', () => {
+
+			const otherTemplate = '<html><body><h1>{{shortLink "https://janis.im"}}</h1></body></html>';
+			const otherTemplateCompiled = Handlebars.compile(otherTemplate, 'strict');
 
 			assert.strictEqual(otherTemplateCompiled({}), '<html><body><h1>#SHORTLINK[https://janis.im]</h1></body></html>');
 		});

--- a/tests/handlebars-helpers-test.js
+++ b/tests/handlebars-helpers-test.js
@@ -1647,4 +1647,36 @@ describe('Handlebars Helpers', () => {
 			assert.strictEqual(templateCompiled(values), '<html><body><h1>100</h1></body></html>');
 		});
 	});
+
+	context('When must render using shortLink helper', () => {
+
+		const template = '<html><body><h1>{{shortLink url}}</h1></body></html>';
+		const templateCompiled = Handlebars.compile(template, 'strict');
+
+		it('Should return template with the formatted link', () => {
+
+			const values = {
+				url: 'https://janis.im'
+			};
+
+			assert.strictEqual(templateCompiled(values), '<html><body><h1>#SHORTLINK[https://janis.im]</h1></body></html>');
+		});
+
+		it('Should return Invalid URL if link has an invalid format', () => {
+
+			const values = {
+				url: 'janis.im'
+			};
+
+			assert.strictEqual(templateCompiled(values), '<html><body><h1>Invalid URL</h1></body></html>');
+		});
+
+		const otherTemplate = '<html><body><h1>{{shortLink "https://janis.im"}}</h1></body></html>';
+		const otherTemplateCompiled = Handlebars.compile(otherTemplate, 'strict');
+
+		it('Should return template with value in string if value is number', () => {
+
+			assert.strictEqual(otherTemplateCompiled({}), '<html><body><h1>#SHORTLINK[https://janis.im]</h1></body></html>');
+		});
+	});
 });

--- a/tests/handlebars-helpers-test.js
+++ b/tests/handlebars-helpers-test.js
@@ -1662,13 +1662,13 @@ describe('Handlebars Helpers', () => {
 			assert.strictEqual(templateCompiled(values), '<html><body><h1>#SHORTLINK[https://janis.im]</h1></body></html>');
 		});
 
-		it('Should return Invalid URL if link has an invalid format', () => {
+		it('Should return an empty string if link has an invalid format', () => {
 
 			const values = {
 				url: 'janis.im'
 			};
 
-			assert.strictEqual(templateCompiled(values), '<html><body><h1>Invalid URL</h1></body></html>');
+			assert.strictEqual(templateCompiled(values), '<html><body><h1></h1></body></html>');
 		});
 
 		const otherTemplate = '<html><body><h1>{{shortLink "https://janis.im"}}</h1></body></html>';

--- a/tests/handlebars-post-compile-test.js
+++ b/tests/handlebars-post-compile-test.js
@@ -13,7 +13,7 @@ const {
 describe('Handlebars PostCompile', () => {
 
 	// eslint-disable-next-line max-len
-	const template = 'Hi! This is my professional website #SHORTLINK[https://www.professional.com], and this my personal website #SHORTLINK[https://www.personal.com]';
+	const template = 'Hi! This is my professional website #SHORTLINK[https://www.professional.com/about?fq=H:197], and this my personal website #SHORTLINK[https://www.personal.com]';
 
 	const shortLink1 = 'https://link.janisdev.in/api/l/G2WTXXZ';
 
@@ -89,7 +89,7 @@ describe('Handlebars PostCompile', () => {
 	context('When keep the original link', () => {
 
 		// eslint-disable-next-line max-len
-		const compiledTemplateWithOriginalLinks = 'Hi! This is my professional website https://www.professional.com, and this my personal website https://www.personal.com';
+		const compiledTemplateWithOriginalLinks = 'Hi! This is my professional website https://www.professional.com/about?fq=H:197, and this my personal website https://www.personal.com';
 
 		it('Should keep the original link if setting is off', async () => {
 

--- a/tests/handlebars-post-compile-test.js
+++ b/tests/handlebars-post-compile-test.js
@@ -1,0 +1,122 @@
+'use strict';
+
+const sinon = require('sinon');
+
+const assert = require('assert');
+
+const { Invoker } = require('@janiscommerce/lambda');
+
+const {
+	Handlebars
+} = require('../lib');
+
+describe('Handlebars PostCompile', () => {
+
+	// eslint-disable-next-line max-len
+	const template = 'Hi! This is my professional website #SHORTLINK[https://www.professional.com], and this my personal website #SHORTLINK[https://www.personal.com]';
+
+	const shortLink1 = 'https://link.janisdev.in/api/l/G2WTXXZ';
+
+	const shortLink2 = 'https://link.janisdev.in/api/l/WD8DUP3';
+
+	const postCompiledTemplate = `Hi! This is my professional website ${shortLink1}, and this my personal website ${shortLink2}`;
+
+	const responseCreateLink = link => ({
+		payload: {
+			shortUrl: link
+		}
+	});
+
+	afterEach(() => {
+		sinon.restore();
+	});
+
+	context('When replace links successfully', () => {
+
+		it('Should compile generating a short link for each different link', async () => {
+
+			sinon.stub(Invoker, 'serviceSafeCall')
+				.onCall(0)
+				.resolves(responseCreateLink(shortLink1))
+				.onCall(1)
+				.resolves(responseCreateLink(shortLink2));
+
+			const postCompileResponse = await Handlebars.postCompile(template);
+			assert.deepStrictEqual(postCompileResponse, postCompiledTemplate);
+
+		});
+
+		it('Should compile without generating a different short link for each identical link', async () => {
+
+			// eslint-disable-next-line max-len
+			const templateWithDuplicatedLink = 'Hi! This is my professional website #SHORTLINK[https://www.professional.com], and here it goes again #SHORTLINK[https://www.professional.com]';
+
+			const compilatedTemplateWithDuplicatedLink = `Hi! This is my professional website ${shortLink1}, and here it goes again ${shortLink1}`;
+
+			sinon.stub(Invoker, 'serviceSafeCall').resolves(responseCreateLink(shortLink1));
+
+			const postCompileResponse = await Handlebars.postCompile(templateWithDuplicatedLink);
+
+			assert.deepStrictEqual(postCompileResponse, compilatedTemplateWithDuplicatedLink);
+
+			sinon.assert.calledOnceWithExactly(Invoker.serviceSafeCall, 'link', 'CreateLink', {
+				target: 'https://www.professional.com'
+			});
+
+		});
+	});
+
+	context('When it does not replace links', () => {
+
+		beforeEach(() => {
+			sinon.spy(Invoker, 'serviceSafeCall');
+		});
+
+
+		it('Should return the same template if there are no links to shorten', async () => {
+
+			const templateWithoutLinks = '<html><body><h1>This is a template without links</h1></body></html>';
+
+			const postCompileResponse = await Handlebars.postCompile(templateWithoutLinks);
+
+			assert.deepStrictEqual(postCompileResponse, templateWithoutLinks);
+
+			sinon.assert.notCalled(Invoker.serviceSafeCall);
+
+		});
+	});
+
+	context('When keep the original link', () => {
+
+		// eslint-disable-next-line max-len
+		const compiledTemplateWithOriginalLinks = 'Hi! This is my professional website https://www.professional.com, and this my personal website https://www.personal.com';
+
+		it('Should keep the original link if setting is off', async () => {
+
+			sinon.spy(Invoker, 'serviceSafeCall');
+
+			const postCompileResponse = await Handlebars.postCompile(template, { shortLink: false });
+
+			assert.deepStrictEqual(postCompileResponse, compiledTemplateWithOriginalLinks);
+
+			sinon.assert.notCalled(Invoker.serviceSafeCall);
+
+		});
+
+		it('Should keep the original link if the link creation fails', async () => {
+
+			sinon.stub(Invoker, 'serviceSafeCall').resolves({
+				statusCode: 500,
+				payload: 'Error creating link'
+			});
+
+			const postCompileResponse = await Handlebars.postCompile(template);
+
+			assert.deepStrictEqual(postCompileResponse, compiledTemplateWithOriginalLinks);
+
+			sinon.assert.calledTwice(Invoker.serviceSafeCall);
+
+		});
+
+	});
+});


### PR DESCRIPTION
**Descripción:**
Nuevo helper `shortLink`  que devuelve los links con un wrapper estilo `#SHORTLINK[linkLargo]`

Ejemplos de uso:

```
{{{shortLink url}}}

{{{shortLink 'https://cdn.microsite.janisdev.in/tracking?client=fizzmodarg&trackingId=' shipping.displayId}}}
```

Nuevo método `postCompile` para generar y reemplazar los links largos con wrapper a links cortos

Este método recibe un parámetro para saber si generar o no los links cortos (para evitar generar links cortos al editar templates)

En caso de que el parámetro sea true, Invoke al MS y reemplazo de los links. Si la generación falla, devuelve el link largo

En caso de que sea false, no genera links y solo elimina el wrapper, devolviendo el link largo

**Descripción de la solución:**

- Se añadió el helper `shortLink `

Este intenta validar si el parámetro ingresado es una URL válida, utilizando el constructor de URL. Si falla, devuelve `Invalid URL`, si tiene éxito, devuelve `#SHORTLINK[link]`

- Se añadió el constructor postCompile
 Se añadió un nuevo constructor, que en el process manipula el template pasado por parámetro para reemplazar todas las ocurrencias `#SHORTLINK[link]` por links generados desde MS Link
Si la generación falla devuelve el link original, sin el wrapper.
Finalmente reemplaza según el link todas las coincidencias en el texto por el link resultante

### CHANGELOG

### Added
- New helper `shortLink`
- New functionality that supports the handling of `#SHORTLINK[link]` pattern in template. [See More](https://github.com/janis-commerce/handlebars/blob/master/docs/postCompile.md)